### PR TITLE
Add tests for runtime module

### DIFF
--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.2a2.dev41+g5f325bf"
+__version__ = '0.1.dev1+g1dd6d87.d20250522'

--- a/tsercom/api/runtime_manager.py
+++ b/tsercom/api/runtime_manager.py
@@ -18,10 +18,8 @@ from tsercom.api.split_process.split_process_error_watcher_source import (
 )
 from tsercom.runtime.runtime_factory import RuntimeFactory
 from tsercom.runtime.runtime_initializer import RuntimeInitializer
-from tsercom.runtime.runtime_main import (
-    initialize_runtimes,
-    remote_process_main,
-)
+# Imports for initialize_runtimes and remote_process_main moved into methods
+# to break circular dependency.
 from tsercom.threading.aio.aio_utils import get_running_loop_or_none
 from tsercom.threading.aio.global_event_loop import (
     create_tsercom_event_loop_from_watcher,
@@ -131,6 +129,7 @@ class RuntimeManager(ErrorWatcher):
         # Start running them. Initialization is performed on the local thread
         # but computation will quickly change using to the provided
         # |event_loop|.
+        from tsercom.runtime.runtime_main import initialize_runtimes # Moved import
         initialize_runtimes(self.__thread_watcher, factories)
 
     def start_out_of_process(
@@ -169,6 +168,7 @@ class RuntimeManager(ErrorWatcher):
         factories = self.__create_factories(factory_factory)
 
         # Create a new process, passing initializers and error queue endpoint.
+        from tsercom.runtime.runtime_main import remote_process_main # Moved import
         self.__process = Process(
             target=partial(remote_process_main, factories, error_sink)
         )

--- a/tsercom/runtime/client/client_runtime_data_handler_unittest.py
+++ b/tsercom/runtime/client/client_runtime_data_handler_unittest.py
@@ -1,0 +1,130 @@
+"""Tests for ClientRuntimeDataHandler."""
+
+import pytest
+from unittest import mock
+
+from tsercom.runtime.client.client_runtime_data_handler import ClientRuntimeDataHandler
+from tsercom.threading.thread_watcher import ThreadWatcher
+from tsercom.data.remote_data_reader import RemoteDataReader # For type hint if needed by mock
+from tsercom.data.annotated_instance import AnnotatedInstance # For type hint
+from tsercom.data.serializable_annotated_instance import SerializableAnnotatedInstance # For type hint
+from tsercom.threading.async_poller import AsyncPoller
+from tsercom.runtime.client.timesync_tracker import TimeSyncTracker
+from tsercom.runtime.id_tracker import IdTracker
+from tsercom.runtime.endpoint_data_processor import EndpointDataProcessor
+from tsercom.caller_id.caller_identifier import CallerIdentifier
+from tsercom.timesync.common.synchronized_clock import SynchronizedClock
+
+
+class TestClientRuntimeDataHandler:
+    """Tests for the ClientRuntimeDataHandler class."""
+
+    @pytest.fixture
+    def mock_thread_watcher(self):
+        return mock.Mock(spec=ThreadWatcher)
+
+    @pytest.fixture
+    def mock_data_reader(self):
+        return mock.Mock(spec=RemoteDataReader)
+
+    @pytest.fixture
+    def mock_event_source_poller(self): 
+        return mock.Mock(spec=AsyncPoller)
+
+
+    @pytest.fixture
+    def mock_time_sync_tracker_instance(self):
+        return mock.Mock(spec=TimeSyncTracker)
+
+    @pytest.fixture
+    def mock_id_tracker_instance(self):
+        return mock.Mock(spec=IdTracker)
+    
+    @pytest.fixture
+    def mock_endpoint_data_processor(self):
+        return mock.Mock(spec=EndpointDataProcessor)
+
+    @pytest.fixture
+    def handler(self, mock_thread_watcher, mock_data_reader, mock_event_source_poller, 
+                mock_time_sync_tracker_instance, mock_id_tracker_instance):
+        with mock.patch('tsercom.runtime.client.client_runtime_data_handler.TimeSyncTracker', return_value=mock_time_sync_tracker_instance) as mock_ts_tracker_class, \
+             mock.patch('tsercom.runtime.client.client_runtime_data_handler.IdTracker', return_value=mock_id_tracker_instance) as mock_id_tracker_class:
+            
+            handler_instance = ClientRuntimeDataHandler(
+                thread_watcher=mock_thread_watcher,
+                data_reader=mock_data_reader,
+                event_source=mock_event_source_poller 
+            )
+            handler_instance._mock_ts_tracker_class = mock_ts_tracker_class
+            handler_instance._mock_id_tracker_class = mock_id_tracker_class
+            handler_instance._mock_time_sync_tracker_instance = mock_time_sync_tracker_instance
+            handler_instance._mock_id_tracker_instance = mock_id_tracker_instance
+            return handler_instance
+
+    def test_init(self, handler, mock_thread_watcher, mock_data_reader, mock_event_source_poller):
+        handler._mock_ts_tracker_class.assert_called_once_with(mock_thread_watcher)
+        handler._mock_id_tracker_class.assert_called_once()
+        
+        assert handler._ClientRuntimeDataHandler__clock_tracker == handler._mock_time_sync_tracker_instance
+        assert handler._ClientRuntimeDataHandler__id_tracker == handler._mock_id_tracker_instance
+        
+        assert handler._RuntimeDataHandlerBase__data_reader == mock_data_reader
+        assert handler._RuntimeDataHandlerBase__event_source == mock_event_source_poller
+
+
+    def test_register_caller(self, handler, mock_endpoint_data_processor):
+        mock_caller_id = CallerIdentifier.random()
+        mock_endpoint = "192.168.1.100"
+        mock_port = 12345
+        
+        mock_synchronized_clock = mock.Mock(spec=SynchronizedClock)
+        handler._mock_time_sync_tracker_instance.on_connect.return_value = mock_synchronized_clock
+
+        with mock.patch.object(handler, '_create_data_processor', return_value=mock_endpoint_data_processor) as mock_create_dp:
+            returned_processor = handler._register_caller(mock_caller_id, mock_endpoint, mock_port)
+
+        handler._mock_id_tracker_instance.add.assert_called_once_with(mock_caller_id, mock_endpoint, mock_port)
+        handler._mock_time_sync_tracker_instance.on_connect.assert_called_once_with(mock_endpoint)
+        mock_create_dp.assert_called_once_with(mock_caller_id, mock_synchronized_clock)
+        assert returned_processor == mock_endpoint_data_processor
+
+    def test_unregister_caller(self, handler):
+        mock_caller_id = CallerIdentifier.random()
+        mock_address = "192.168.1.200"
+        mock_port = 54321
+        
+        handler._mock_id_tracker_instance.get.return_value = (mock_address, mock_port)
+        
+        with pytest.raises(AssertionError) as excinfo:
+            handler._unregister_caller(mock_caller_id)
+        
+        handler._mock_id_tracker_instance.get.assert_called_once_with(mock_caller_id) 
+        
+        # self.__clock_tracker.on_disconnect(address) is NOT called due to the assert False
+        handler._mock_time_sync_tracker_instance.on_disconnect.assert_not_called()
+        
+        assert "Find out if I should be keeping or deleting these?" in str(excinfo.value)
+
+    def test_try_get_caller_id(self, handler):
+        mock_endpoint = "10.0.0.1"
+        mock_port = 8080
+        expected_caller_id = CallerIdentifier.random()
+        
+        handler._mock_id_tracker_instance.try_get.return_value = expected_caller_id
+        
+        returned_caller_id = handler._try_get_caller_id(mock_endpoint, mock_port)
+        
+        handler._mock_id_tracker_instance.try_get.assert_called_once_with(mock_endpoint, mock_port)
+        assert returned_caller_id == expected_caller_id
+
+    def test_try_get_caller_id_not_found(self, handler):
+        mock_endpoint = "10.0.0.2"
+        mock_port = 8081
+        
+        handler._mock_id_tracker_instance.try_get.return_value = None 
+        
+        returned_caller_id = handler._try_get_caller_id(mock_endpoint, mock_port)
+        
+        handler._mock_id_tracker_instance.try_get.assert_called_once_with(mock_endpoint, mock_port)
+        assert returned_caller_id is None
+# Removed final syntax error.

--- a/tsercom/runtime/client/timesync_tracker.py
+++ b/tsercom/runtime/client/timesync_tracker.py
@@ -8,7 +8,7 @@ class TimeSyncTracker:
     def __init__(self, thread_watcher: ThreadWatcher):
         self.__thread_watcher = thread_watcher
 
-        self.__map = Dict[str, tuple[int, TimeSyncClient]]
+        self.__map: Dict[str, tuple[int, TimeSyncClient]] = {}
 
     def on_connect(self, ip: str) -> SynchronizedClock:
         if ip not in self.__map:
@@ -19,14 +19,23 @@ class TimeSyncTracker:
             return new_client.get_synchronized_clock()
 
         else:
-            count_and_sync: tuple[int, TimeSyncClient] = self.__map[ip]
-            count_and_sync[0] += 1
-            return count_and_sync[1].get_synchronized_clock()
+            # Retrieve and update the count.
+            # Note: Tuples are immutable, so we have to create a new one.
+            current_count, client_instance = self.__map[ip]
+            current_count += 1
+            self.__map[ip] = (current_count, client_instance)
+            return client_instance.get_synchronized_clock()
 
     def on_disconnect(self, ip: str):
         assert ip in self.__map
-        count_and_sync: tuple[int, TimeSyncClient] = self.__map[ip]
-        count_and_sync[0] -= 1
-        if count_and_sync[0] == 0:
+        
+        # Retrieve and update the count.
+        # Note: Tuples are immutable, so we have to create a new one.
+        current_count, client_instance = self.__map[ip]
+        current_count -= 1
+
+        if current_count == 0:
             del self.__map[ip]
-            count_and_sync[1].stop()
+            client_instance.stop()
+        else:
+            self.__map[ip] = (current_count, client_instance)

--- a/tsercom/runtime/client/timesync_tracker_unittest.py
+++ b/tsercom/runtime/client/timesync_tracker_unittest.py
@@ -1,0 +1,146 @@
+"""Tests for TimeSyncTracker."""
+
+import pytest
+from unittest import mock
+
+from tsercom.runtime.client.timesync_tracker import TimeSyncTracker
+from tsercom.threading.thread_watcher import ThreadWatcher
+from tsercom.timesync.client.time_sync_client import TimeSyncClient
+from tsercom.timesync.common.synchronized_clock import SynchronizedClock
+
+
+class TestTimeSyncTracker:
+    """Tests for the TimeSyncTracker class."""
+
+    @pytest.fixture
+    def mock_thread_watcher(self):
+        return mock.Mock(spec=ThreadWatcher)
+
+    @pytest.fixture
+    def mock_time_sync_client_class(self):
+        with mock.patch('tsercom.runtime.client.timesync_tracker.TimeSyncClient', autospec=True) as mock_class:
+            mock_instance = mock_class.return_value
+            mock_instance.get_synchronized_clock.return_value = mock.Mock(spec=SynchronizedClock)
+            yield mock_class
+
+    def test_on_connect_new_ip(self, mock_thread_watcher, mock_time_sync_client_class):
+        """Test on_connect when a new IP address is encountered."""
+        tracker = TimeSyncTracker(mock_thread_watcher)
+        test_ip = "192.168.1.100"
+        
+        actual_client_instance_created = mock_time_sync_client_class.return_value 
+        mock_synchronized_clock = actual_client_instance_created.get_synchronized_clock.return_value
+
+        returned_clock = tracker.on_connect(test_ip)
+
+        mock_time_sync_client_class.assert_called_once_with(
+            mock_thread_watcher, 
+            test_ip              
+        )
+        actual_client_instance_created.start_async.assert_called_once()
+        assert tracker._TimeSyncTracker__map[test_ip][1] == actual_client_instance_created
+        assert tracker._TimeSyncTracker__map[test_ip][0] == 1 
+        actual_client_instance_created.get_synchronized_clock.assert_called_once()
+        assert returned_clock == mock_synchronized_clock
+
+    def test_on_connect_existing_ip(self, mock_thread_watcher, mock_time_sync_client_class):
+        """Test on_connect when an IP address is already being tracked."""
+        tracker = TimeSyncTracker(mock_thread_watcher)
+        test_ip = "192.168.1.101"
+
+        original_client_instance = mock_time_sync_client_class.return_value 
+        mock_synchronized_clock = original_client_instance.get_synchronized_clock.return_value
+
+        # First connection
+        tracker.on_connect(test_ip)
+        
+        # Assertions after first call
+        mock_time_sync_client_class.assert_called_once_with(mock_thread_watcher, test_ip)
+        original_client_instance.start_async.assert_called_once()
+        original_client_instance.get_synchronized_clock.assert_called_once()
+        
+        # Second connection to the same IP
+        returned_clock_second = tracker.on_connect(test_ip)
+
+        # Assertions after second call:
+        # 1. Constructor TimeSyncClient() should still have been called only once (from the first connect).
+        mock_time_sync_client_class.assert_called_once_with(mock_thread_watcher, test_ip)
+        
+        # 2. start_async on the original client instance should still only have been called once.
+        original_client_instance.start_async.assert_called_once() 
+        
+        # 3. Check map content and count
+        assert tracker._TimeSyncTracker__map[test_ip][1] == original_client_instance
+        assert tracker._TimeSyncTracker__map[test_ip][0] == 2
+        
+        # 4. get_synchronized_clock on the original client instance should have been called twice now.
+        assert original_client_instance.get_synchronized_clock.call_count == 2 
+        assert returned_clock_second == mock_synchronized_clock
+
+    def test_on_disconnect_count_greater_than_one(self, mock_thread_watcher, mock_time_sync_client_class):
+        tracker = TimeSyncTracker(mock_thread_watcher)
+        test_ip = "192.168.1.102"
+        client_instance = mock_time_sync_client_class.return_value
+
+        tracker.on_connect(test_ip)
+        tracker.on_connect(test_ip) 
+        assert tracker._TimeSyncTracker__map[test_ip][0] == 2
+
+        tracker.on_disconnect(test_ip) 
+
+        assert tracker._TimeSyncTracker__map[test_ip][0] == 1
+        client_instance.stop.assert_not_called() 
+        assert test_ip in tracker._TimeSyncTracker__map
+
+    def test_on_disconnect_count_equals_one(self, mock_thread_watcher, mock_time_sync_client_class):
+        tracker = TimeSyncTracker(mock_thread_watcher)
+        test_ip = "192.168.1.103"
+        client_instance = mock_time_sync_client_class.return_value
+
+        tracker.on_connect(test_ip) 
+        assert tracker._TimeSyncTracker__map[test_ip][0] == 1
+        
+        tracker.on_disconnect(test_ip) 
+
+        assert test_ip not in tracker._TimeSyncTracker__map
+        client_instance.stop.assert_called_once()
+
+    def test_on_disconnect_non_existent_ip(self, mock_thread_watcher):
+        tracker = TimeSyncTracker(mock_thread_watcher)
+        test_ip = "192.168.1.104"
+
+        with pytest.raises(AssertionError): 
+            tracker.on_disconnect(test_ip)
+
+    def test_on_connect_different_ips(self, mock_thread_watcher, mock_time_sync_client_class):
+        tracker = TimeSyncTracker(mock_thread_watcher)
+        ip1 = "192.168.1.1"
+        ip2 = "192.168.1.2"
+
+        mock_client_instance1 = mock.Mock(spec=TimeSyncClient)
+        mock_clock1 = mock.Mock(spec=SynchronizedClock)
+        mock_client_instance1.get_synchronized_clock.return_value = mock_clock1
+        
+        mock_client_instance2 = mock.Mock(spec=TimeSyncClient)
+        mock_clock2 = mock.Mock(spec=SynchronizedClock)
+        mock_client_instance2.get_synchronized_clock.return_value = mock_clock2
+
+        mock_time_sync_client_class.side_effect = [mock_client_instance1, mock_client_instance2]
+
+        returned_clock1 = tracker.on_connect(ip1)
+        mock_time_sync_client_class.assert_any_call(mock_thread_watcher, ip1)
+        mock_client_instance1.start_async.assert_called_once()
+        assert tracker._TimeSyncTracker__map[ip1][1] == mock_client_instance1
+        assert tracker._TimeSyncTracker__map[ip1][0] == 1
+        assert returned_clock1 == mock_clock1
+        
+        returned_clock2 = tracker.on_connect(ip2)
+        mock_time_sync_client_class.assert_any_call(mock_thread_watcher, ip2)
+        mock_client_instance2.start_async.assert_called_once()
+        assert tracker._TimeSyncTracker__map[ip2][1] == mock_client_instance2
+        assert tracker._TimeSyncTracker__map[ip2][0] == 1
+        assert returned_clock2 == mock_clock2
+
+        assert len(tracker._TimeSyncTracker__map) == 2
+        assert mock_time_sync_client_class.call_count == 2
+# Removed final syntax error.

--- a/tsercom/runtime/id_tracker.py
+++ b/tsercom/runtime/id_tracker.py
@@ -40,7 +40,7 @@ class IdTracker:
 
         else:
             with self.__lock:
-                if id not in self.__address_to_id:
+                if (address, port) not in self.__address_to_id:
                     return None
                 return self.__address_to_id[(address, port)]
 

--- a/tsercom/runtime/id_tracker_unittest.py
+++ b/tsercom/runtime/id_tracker_unittest.py
@@ -1,0 +1,191 @@
+"""Tests for IdTracker."""
+
+import pytest
+from unittest import mock
+import uuid
+
+from tsercom.caller_id.caller_identifier import CallerIdentifier
+from tsercom.runtime.id_tracker import IdTracker
+
+
+class TestIdTracker:
+    """Tests for the IdTracker class."""
+
+    def test_add_and_get_id(self):
+        """Test adding and retrieving an ID."""
+        tracker = IdTracker()
+        caller_id = CallerIdentifier.random()
+        ip_address = '127.0.0.1'
+        port = 8080
+        tracker.add(caller_id, ip_address, port)
+
+        assert tracker.get(address=ip_address, port=port) == caller_id
+        assert tracker.get(id=caller_id) == (ip_address, port)
+
+    def test_try_get_id(self):
+        """Test try_get method."""
+        tracker = IdTracker()
+        caller_id = CallerIdentifier.random()
+        ip_address = '127.0.0.1'
+        port = 8080
+        tracker.add(caller_id, ip_address, port)
+
+        assert tracker.try_get(address=ip_address, port=port) == caller_id
+        assert tracker.try_get(id=caller_id) == (ip_address, port)
+        assert tracker.try_get(address='nonexistent', port=123) is None
+        assert tracker.try_get(id=CallerIdentifier.random()) is None # Test with a new random ID
+
+    def test_get_non_existing(self):
+        """Test get method for non-existing entries."""
+        tracker = IdTracker()
+        with pytest.raises(KeyError):
+            tracker.get(address='127.0.0.1', port=8080)
+        with pytest.raises(KeyError):
+            tracker.get(id=CallerIdentifier.random())
+
+    def test_has_id_and_has_address(self):
+        """Test has_id and has_address methods."""
+        tracker = IdTracker()
+        caller_id = CallerIdentifier.random()
+        ip_address = '127.0.0.1'
+        port = 8080
+        tracker.add(caller_id, ip_address, port)
+
+        assert tracker.has_id(caller_id)
+        assert not tracker.has_id(CallerIdentifier.random())
+        assert tracker.has_address(ip_address, port)
+        assert not tracker.has_address('nonexistent', 123)
+
+    def test_add_duplicate_id_raises_key_error(self):
+        """Test adding a duplicate ID raises KeyError."""
+        tracker = IdTracker()
+        caller_id1 = CallerIdentifier.random()
+        ip_address1 = '127.0.0.1'
+        port1 = 8080
+        ip_address2 = '192.168.1.1'
+        port2 = 9090
+        tracker.add(caller_id1, ip_address1, port1)
+        with pytest.raises(KeyError):
+            tracker.add(caller_id1, ip_address2, port2)
+
+    def test_add_duplicate_address_raises_key_error(self):
+        """Test adding a duplicate address/port pair raises KeyError."""
+        tracker = IdTracker()
+        caller_id1 = CallerIdentifier.random()
+        caller_id2 = CallerIdentifier.random()
+        ip_address = '127.0.0.1'
+        port = 8080
+        tracker.add(caller_id1, ip_address, port)
+        with pytest.raises(KeyError):
+            tracker.add(caller_id2, ip_address, port)
+
+    def test_len(self):
+        """Test __len__ method."""
+        tracker = IdTracker()
+        assert len(tracker) == 0
+        caller_id1 = CallerIdentifier.random()
+        ip_address1 = '127.0.0.1'
+        port1 = 8080
+        tracker.add(caller_id1, ip_address1, port1)
+        assert len(tracker) == 1
+        
+        caller_id2 = CallerIdentifier.random()
+        ip_address2 = '192.168.1.1'
+        port2 = 9090
+        tracker.add(caller_id2, ip_address2, port2)
+        assert len(tracker) == 2
+
+    def test_iter(self):
+        """Test __iter__ method."""
+        tracker = IdTracker()
+        
+        ids_to_add = {CallerIdentifier.random() for _ in range(3)}
+        addresses = [
+            ('127.0.0.1', 8080),
+            ('127.0.0.2', 8081),
+            ('127.0.0.3', 8082),
+        ]
+
+        added_ids = set()
+        for i, caller_id in enumerate(ids_to_add):
+            tracker.add(caller_id, addresses[i][0], addresses[i][1])
+            added_ids.add(caller_id)
+
+        iterated_ids = set()
+        for id_val in tracker:
+            iterated_ids.add(id_val)
+        assert iterated_ids == added_ids
+
+    # Removed tests for 'remove' method as it does not exist on IdTracker
+    # test_remove
+    # test_remove_non_existing_id_raises_key_error
+    # test_get_id_after_remove
+    # test_add_after_remove
+    # test_complex_scenario (as it heavily relied on remove)
+
+    def test_integration_add_get_has_len(self):
+        """Test a sequence of operations: add, get, has_id, has_address, len."""
+        tracker = IdTracker()
+        
+        # Initial state
+        assert len(tracker) == 0
+        random_id_init = CallerIdentifier.random()
+        assert not tracker.has_id(random_id_init)
+        assert not tracker.has_address("10.0.0.1", 1001)
+
+        # Add first entry
+        caller1 = CallerIdentifier.random()
+        addr1 = ("10.0.0.1", 1001)
+        tracker.add(caller1, addr1[0], addr1[1])
+        
+        assert len(tracker) == 1
+        assert tracker.has_id(caller1)
+        assert not tracker.has_id(random_id_init) # Should still be false for a different ID
+        assert tracker.has_address(addr1[0], addr1[1])
+        assert tracker.get(id=caller1) == addr1
+        assert tracker.get(address=addr1[0], port=addr1[1]) == caller1
+        
+        # Add second entry
+        caller2 = CallerIdentifier.random()
+        addr2 = ("10.0.0.2", 1002)
+        tracker.add(caller2, addr2[0], addr2[1])
+
+        assert len(tracker) == 2
+        assert tracker.has_id(caller2)
+        assert tracker.has_address(addr2[0], addr2[1])
+        assert tracker.get(id=caller2) == addr2
+        assert tracker.get(address=addr2[0], port=addr2[1]) == caller2
+
+        # Check first entry again
+        assert tracker.has_id(caller1)
+        assert tracker.has_address(addr1[0], addr1[1])
+        assert tracker.get(id=caller1) == addr1
+        
+        # Test try_get for existing and non-existing
+        assert tracker.try_get(id=caller1) == addr1
+        non_existing_caller = CallerIdentifier.random()
+        assert tracker.try_get(id=non_existing_caller) is None
+        assert tracker.try_get(address="10.0.0.3", port=1003) is None
+
+        # Test iteration contains all added ids
+        iterated_ids = set()
+        for id_val in tracker:
+            iterated_ids.add(id_val)
+        assert iterated_ids == {caller1, caller2}
+
+        # Test KeyErrors for non-existent gets
+        with pytest.raises(KeyError):
+            tracker.get(id=non_existing_caller)
+        with pytest.raises(KeyError):
+            tracker.get(address="10.0.0.3", port=1003)
+
+        # Test KeyErrors for duplicate adds
+        caller_temp = CallerIdentifier.random()
+        with pytest.raises(KeyError): # Duplicate address
+            tracker.add(caller_temp, addr1[0], addr1[1])
+        with pytest.raises(KeyError): # Duplicate ID
+            tracker.add(caller1, "10.0.0.4", 1004)
+        
+        assert len(tracker) == 2 # Length should remain unchanged after failed adds
+# Removed accidental backticks from previous edit
+# ``` was here

--- a/tsercom/runtime/runtime_config_unittest.py
+++ b/tsercom/runtime/runtime_config_unittest.py
@@ -1,0 +1,144 @@
+"""Tests for RuntimeConfig."""
+
+import pytest
+from unittest import mock
+
+from tsercom.runtime.runtime_config import RuntimeConfig, ServiceType
+from tsercom.data.remote_data_aggregator import RemoteDataAggregator
+
+
+class TestRuntimeConfig:
+    """Tests for the RuntimeConfig class."""
+
+    def test_init_with_client_string(self):
+        """Test initialization with service_type='Client'."""
+        config = RuntimeConfig(service_type="Client")
+        assert config.is_client()
+        assert not config.is_server()
+        # Accessing private __service_type for exact enum check
+        assert config._RuntimeConfig__service_type == ServiceType.kClient
+
+
+    def test_init_with_server_string(self):
+        """Test initialization with service_type='Server'."""
+        config = RuntimeConfig(service_type="Server")
+        assert not config.is_client()
+        assert config.is_server()
+        assert config._RuntimeConfig__service_type == ServiceType.kServer
+
+
+    def test_init_with_client_enum(self):
+        """Test initialization with ServiceType.kClient."""
+        config = RuntimeConfig(service_type=ServiceType.kClient)
+        assert config.is_client()
+        assert not config.is_server()
+        assert config._RuntimeConfig__service_type == ServiceType.kClient
+
+    def test_init_with_server_enum(self):
+        """Test initialization with ServiceType.kServer."""
+        config = RuntimeConfig(service_type=ServiceType.kServer)
+        assert not config.is_client()
+        assert config.is_server()
+        assert config._RuntimeConfig__service_type == ServiceType.kServer
+
+    def test_init_copy_constructor_client(self):
+        """Test initialization by copying from another Client RuntimeConfig."""
+        mock_aggregator = mock.Mock(spec=RemoteDataAggregator)
+        original_config = RuntimeConfig(service_type="Client", timeout_seconds=30, data_aggregator_client=mock_aggregator)
+        
+        copied_config = RuntimeConfig(other_config=original_config) # Use other_config parameter
+        
+        assert copied_config.is_client()
+        assert not copied_config.is_server()
+        assert copied_config._RuntimeConfig__service_type == ServiceType.kClient
+        assert copied_config.timeout_seconds == 30
+        assert copied_config.data_aggregator_client == mock_aggregator
+
+    def test_init_copy_constructor_server(self):
+        """Test initialization by copying from another Server RuntimeConfig."""
+        mock_aggregator_server = mock.Mock(spec=RemoteDataAggregator)
+        original_config = RuntimeConfig(service_type="Server", timeout_seconds=45, data_aggregator_client=mock_aggregator_server)
+
+        copied_config = RuntimeConfig(other_config=original_config) # Use other_config parameter
+
+        assert not copied_config.is_client()
+        assert copied_config.is_server()
+        assert copied_config._RuntimeConfig__service_type == ServiceType.kServer
+        assert copied_config.timeout_seconds == 45
+        # Based on implementation, data_aggregator_client is copied regardless of service type
+        assert copied_config.data_aggregator_client == mock_aggregator_server
+
+
+    def test_default_values(self):
+        """Test default timeout_seconds and data_aggregator_client."""
+        config_client = RuntimeConfig(service_type="Client")
+        assert config_client.timeout_seconds == 60
+        assert config_client.data_aggregator_client is None
+
+        config_server = RuntimeConfig(service_type="Server")
+        assert config_server.timeout_seconds == 60
+        assert config_server.data_aggregator_client is None 
+
+    def test_custom_timeout_seconds(self):
+        """Test providing a custom timeout_seconds value."""
+        config = RuntimeConfig(service_type="Client", timeout_seconds=120)
+        assert config.timeout_seconds == 120
+
+    def test_custom_data_aggregator_client_for_client(self):
+        """Test providing a custom data_aggregator_client for Client type."""
+        mock_aggregator = mock.Mock(spec=RemoteDataAggregator)
+        config = RuntimeConfig(service_type="Client", data_aggregator_client=mock_aggregator)
+        assert config.data_aggregator_client == mock_aggregator
+
+    def test_custom_data_aggregator_client_for_server(self):
+        """Test providing a custom data_aggregator_client for Server type."""
+        mock_aggregator = mock.Mock(spec=RemoteDataAggregator)
+        # Based on implementation, this should be set for server as well if provided.
+        config = RuntimeConfig(service_type="Server", data_aggregator_client=mock_aggregator)
+        assert config.data_aggregator_client == mock_aggregator
+
+
+    def test_invalid_service_type_string(self):
+        """Test initialization with an invalid service_type string raises ValueError."""
+        invalid_type = "InvalidType"
+        with pytest.raises(ValueError) as excinfo:
+            RuntimeConfig(service_type=invalid_type)
+        assert f"Invalid service type: {invalid_type}" == str(excinfo.value)
+
+    def test_data_aggregator_client_property(self):
+        """Test the data_aggregator_client property returns the correct object."""
+        mock_aggregator = mock.Mock(spec=RemoteDataAggregator)
+        # Set via constructor to test property getter
+        config = RuntimeConfig(service_type="Client", data_aggregator_client=mock_aggregator)
+        assert config.data_aggregator_client == mock_aggregator
+
+        config_none = RuntimeConfig(service_type="Client")
+        assert config_none.data_aggregator_client is None
+
+
+    def test_timeout_seconds_property(self):
+        """Test the timeout_seconds property returns the correct value."""
+        config = RuntimeConfig(service_type="Client", timeout_seconds=90)
+        assert config.timeout_seconds == 90
+        
+        config_default = RuntimeConfig(service_type="Server") # Default timeout
+        assert config_default.timeout_seconds == 60
+
+    def test_is_client_is_server_methods(self):
+        """Test is_client and is_server methods thoroughly."""
+        client_config = RuntimeConfig(service_type=ServiceType.kClient)
+        assert client_config.is_client() is True
+        assert client_config.is_server() is False
+
+        server_config = RuntimeConfig(service_type=ServiceType.kServer)
+        assert server_config.is_client() is False
+        assert server_config.is_server() is True
+
+    def test_constructor_assertion_service_type_vs_other_config(self):
+        """Test assertion that only one of service_type or other_config is provided."""
+        with pytest.raises(AssertionError):
+            RuntimeConfig(service_type="Client", other_config=RuntimeConfig(service_type="Server"))
+        
+        with pytest.raises(AssertionError):
+            RuntimeConfig() # Neither provided
+# Removed final backticks that caused syntax error.

--- a/tsercom/runtime/runtime_main_unittest.py
+++ b/tsercom/runtime/runtime_main_unittest.py
@@ -1,0 +1,249 @@
+"""Tests for tsercom.runtime.runtime_main."""
+
+import pytest
+from unittest import mock
+import asyncio # For run_on_event_loop side_effect
+
+from tsercom.runtime.runtime_main import initialize_runtimes, remote_process_main
+from tsercom.runtime.runtime_factory import RuntimeFactory
+from tsercom.runtime.runtime import Runtime
+from tsercom.runtime.runtime_config import ServiceType # Corrected import
+from tsercom.rpc.grpc.grpc_channel_factory import GrpcChannelFactory
+from tsercom.data.remote_data_reader import RemoteDataReader
+from tsercom.threading.async_poller import AsyncPoller
+from tsercom.threading.thread_watcher import ThreadWatcher
+from tsercom.api.split_process.data_reader_sink import DataReaderSink 
+from tsercom.api.split_process.split_process_error_watcher_sink import SplitProcessErrorWatcherSink
+
+
+@mock.patch('tsercom.runtime.runtime_main.is_global_event_loop_set', return_value=True)
+@mock.patch('tsercom.runtime.runtime_main.run_on_event_loop', side_effect=lambda coro, loop=None: None) 
+@mock.patch('tsercom.runtime.runtime_main.ChannelFactorySelector') # Patches the class
+@mock.patch('tsercom.runtime.runtime_main.ClientRuntimeDataHandler')
+@mock.patch('tsercom.runtime.runtime_main.ServerRuntimeDataHandler')
+class TestInitializeRuntimes:
+    """Tests for the initialize_runtimes function."""
+
+    def test_initialize_runtimes_client(
+        self,
+        MockServerRuntimeDataHandler, 
+        MockClientRuntimeDataHandler, 
+        MockChannelFactorySelector,   
+        mock_run_on_event_loop, 
+        mock_is_global_event_loop_set 
+    ):
+        mock_thread_watcher = mock.Mock(spec=ThreadWatcher)
+        
+        mock_channel_factory_selector_instance = MockChannelFactorySelector.return_value
+        mock_grpc_channel_factory = mock.Mock(spec=GrpcChannelFactory)
+        mock_channel_factory_selector_instance.get_instance.return_value = mock_grpc_channel_factory
+
+        mock_client_factory = mock.Mock(spec=RuntimeFactory)
+        mock_client_factory.is_client.return_value = True
+        mock_client_factory.is_server.return_value = False
+        mock_client_factory.remote_data_reader = mock.Mock(spec=RemoteDataReader)
+        mock_client_factory.event_poller = mock.Mock(spec=AsyncPoller)
+        
+        mock_runtime_instance = mock.Mock(spec=Runtime)
+        mock_runtime_instance.start_async = mock.Mock(name="start_async_method") 
+        mock_client_factory.create.return_value = mock_runtime_instance
+
+        initializers = [mock_client_factory]
+        created_runtimes = initialize_runtimes(mock_thread_watcher, initializers)
+
+        mock_is_global_event_loop_set.assert_called_once()
+        MockChannelFactorySelector.assert_called_once_with() 
+        mock_channel_factory_selector_instance.get_instance.assert_called_once_with() 
+        
+        MockClientRuntimeDataHandler.assert_called_once_with(
+            mock_thread_watcher, 
+            mock_client_factory.remote_data_reader, 
+            mock_client_factory.event_poller 
+        )
+        MockServerRuntimeDataHandler.assert_not_called()
+        mock_client_factory.create.assert_called_once_with(
+            mock_thread_watcher, 
+            MockClientRuntimeDataHandler.return_value, 
+            mock_grpc_channel_factory 
+        )
+        mock_run_on_event_loop.assert_called_once_with(mock_runtime_instance.start_async) 
+        assert created_runtimes == [mock_runtime_instance]
+
+    def test_initialize_runtimes_server(
+        self,
+        MockServerRuntimeDataHandler,
+        MockClientRuntimeDataHandler,
+        MockChannelFactorySelector,
+        mock_run_on_event_loop,
+        mock_is_global_event_loop_set
+    ):
+        mock_thread_watcher = mock.Mock(spec=ThreadWatcher)
+        mock_channel_factory_selector_instance = MockChannelFactorySelector.return_value
+        mock_grpc_channel_factory = mock.Mock(spec=GrpcChannelFactory)
+        mock_channel_factory_selector_instance.get_instance.return_value = mock_grpc_channel_factory
+
+        mock_server_factory = mock.Mock(spec=RuntimeFactory)
+        mock_server_factory.is_client.return_value = False
+        mock_server_factory.is_server.return_value = True
+        mock_server_factory.remote_data_reader = mock.Mock(spec=RemoteDataReader)
+        mock_server_factory.event_poller = mock.Mock(spec=AsyncPoller)
+
+        mock_runtime_instance = mock.Mock(spec=Runtime)
+        mock_runtime_instance.start_async = mock.Mock(name="start_async_method")
+        mock_server_factory.create.return_value = mock_runtime_instance
+
+        initializers = [mock_server_factory]
+        created_runtimes = initialize_runtimes(mock_thread_watcher, initializers)
+
+        mock_is_global_event_loop_set.assert_called_once()
+        MockChannelFactorySelector.assert_called_once_with()
+        mock_channel_factory_selector_instance.get_instance.assert_called_once_with()
+
+        MockServerRuntimeDataHandler.assert_called_once_with(
+            mock_server_factory.remote_data_reader, 
+            mock_server_factory.event_poller        
+        )
+        MockClientRuntimeDataHandler.assert_not_called()
+        mock_server_factory.create.assert_called_once_with(
+            mock_thread_watcher,
+            MockServerRuntimeDataHandler.return_value, 
+            mock_grpc_channel_factory
+        )
+        mock_run_on_event_loop.assert_called_once_with(mock_runtime_instance.start_async)
+        assert created_runtimes == [mock_runtime_instance]
+
+    def test_initialize_runtimes_multiple(
+        self,
+        MockServerRuntimeDataHandler,
+        MockClientRuntimeDataHandler,
+        MockChannelFactorySelector,
+        mock_run_on_event_loop,
+        mock_is_global_event_loop_set
+    ):
+        mock_thread_watcher = mock.Mock(spec=ThreadWatcher)
+        mock_channel_factory_selector_instance = MockChannelFactorySelector.return_value
+        mock_grpc_channel_factory = mock.Mock(spec=GrpcChannelFactory)
+        mock_channel_factory_selector_instance.get_instance.return_value = mock_grpc_channel_factory
+
+        mock_client_factory = mock.Mock(spec=RuntimeFactory)
+        mock_client_factory.is_client.return_value = True
+        mock_client_factory.is_server.return_value = False
+        mock_client_factory.remote_data_reader = mock.Mock(spec=RemoteDataReader, name="client_reader")
+        mock_client_factory.event_poller = mock.Mock(spec=AsyncPoller, name="client_poller")
+        mock_client_runtime = mock.Mock(spec=Runtime, name="client_runtime")
+        mock_client_runtime.start_async = mock.Mock(name="client_start_async")
+        mock_client_factory.create.return_value = mock_client_runtime
+
+        mock_server_factory = mock.Mock(spec=RuntimeFactory)
+        mock_server_factory.is_client.return_value = False
+        mock_server_factory.is_server.return_value = True
+        mock_server_factory.remote_data_reader = mock.Mock(spec=RemoteDataReader, name="server_reader")
+        mock_server_factory.event_poller = mock.Mock(spec=AsyncPoller, name="server_poller")
+        mock_server_runtime = mock.Mock(spec=Runtime, name="server_runtime")
+        mock_server_runtime.start_async = mock.Mock(name="server_start_async")
+        mock_server_factory.create.return_value = mock_server_runtime
+        
+        initializers = [mock_client_factory, mock_server_factory]
+        created_runtimes = initialize_runtimes(mock_thread_watcher, initializers)
+        
+        MockChannelFactorySelector.assert_called_once_with() 
+        mock_channel_factory_selector_instance.get_instance.assert_called_once_with()
+
+        assert MockClientRuntimeDataHandler.call_count == 1
+        MockClientRuntimeDataHandler.assert_any_call( 
+            mock_thread_watcher,
+            mock_client_factory.remote_data_reader,
+            mock_client_factory.event_poller
+        )
+        assert MockServerRuntimeDataHandler.call_count == 1
+        MockServerRuntimeDataHandler.assert_any_call(
+            mock_server_factory.remote_data_reader,
+            mock_server_factory.event_poller
+        )
+        
+        mock_client_factory.create.assert_called_once()
+        mock_server_factory.create.assert_called_once()
+        
+        assert mock_run_on_event_loop.call_count == 2
+        mock_run_on_event_loop.assert_any_call(mock_client_runtime.start_async)
+        mock_run_on_event_loop.assert_any_call(mock_server_runtime.start_async)
+        
+        assert created_runtimes == [mock_client_runtime, mock_server_runtime]
+
+
+@mock.patch('tsercom.runtime.runtime_main.clear_tsercom_event_loop')
+@mock.patch('tsercom.runtime.runtime_main.ThreadWatcher', return_value=mock.Mock(spec=ThreadWatcher))
+@mock.patch('tsercom.runtime.runtime_main.create_tsercom_event_loop_from_watcher')
+@mock.patch('tsercom.runtime.runtime_main.SplitProcessErrorWatcherSink')
+@mock.patch('tsercom.runtime.runtime_main.initialize_runtimes')
+@mock.patch('tsercom.runtime.runtime_main.run_on_event_loop', side_effect=lambda coro, loop=None: None)
+class TestRemoteProcessMain:
+    """Tests for the remote_process_main function."""
+
+    def test_normal_execution(
+        self,
+        mock_run_on_event_loop,
+        mock_initialize_runtimes,
+        MockSplitProcessErrorWatcherSink,
+        mock_create_event_loop,
+        MockThreadWatcher,
+        mock_clear_event_loop
+    ):
+        mock_factories = [mock.Mock(spec=RuntimeFactory)]
+        mock_error_queue = mock.Mock(spec=DataReaderSink) 
+        
+        mock_runtime1 = mock.Mock(spec=Runtime)
+        mock_runtime1.stop = mock.Mock(name="runtime1_stop") 
+        mock_runtime2 = mock.Mock(spec=Runtime)
+        mock_runtime2.stop = mock.Mock(name="runtime2_stop") 
+        mock_initialize_runtimes.return_value = [mock_runtime1, mock_runtime2]
+        
+        mock_sink_instance = MockSplitProcessErrorWatcherSink.return_value
+
+        remote_process_main(mock_factories, mock_error_queue)
+
+        mock_clear_event_loop.assert_called_once()
+        MockThreadWatcher.assert_called_once()
+        mock_create_event_loop.assert_called_once_with(MockThreadWatcher.return_value)
+        MockSplitProcessErrorWatcherSink.assert_called_once_with(
+            MockThreadWatcher.return_value, 
+            mock_error_queue               
+        )
+        mock_initialize_runtimes.assert_called_once_with(
+            MockThreadWatcher.return_value, mock_factories
+        )
+        mock_sink_instance.run_until_exception.assert_called_once()
+        
+        assert mock_run_on_event_loop.call_count == 2 
+        mock_run_on_event_loop.assert_any_call(mock_runtime1.stop)
+        mock_run_on_event_loop.assert_any_call(mock_runtime2.stop)
+
+    def test_exception_in_run_until_exception(
+        self,
+        mock_run_on_event_loop,
+        mock_initialize_runtimes,
+        MockSplitProcessErrorWatcherSink,
+        mock_create_event_loop, 
+        MockThreadWatcher,      
+        mock_clear_event_loop   
+    ):
+        mock_factories = [mock.Mock(spec=RuntimeFactory)]
+        mock_error_queue = mock.Mock(spec=DataReaderSink) 
+        
+        mock_runtime1 = mock.Mock(spec=Runtime)
+        mock_runtime1.stop = mock.Mock(name="runtime1_stop") 
+        mock_runtime2 = mock.Mock(spec=Runtime)
+        mock_runtime2.stop = mock.Mock(name="runtime2_stop") 
+        mock_initialize_runtimes.return_value = [mock_runtime1, mock_runtime2]
+        
+        mock_sink_instance = MockSplitProcessErrorWatcherSink.return_value
+        test_exception = RuntimeError("Test error from sink")
+        mock_sink_instance.run_until_exception.side_effect = test_exception
+
+        with pytest.raises(RuntimeError, match="Test error from sink"):
+            remote_process_main(mock_factories, mock_error_queue)
+
+        assert mock_run_on_event_loop.call_count == 2
+        mock_run_on_event_loop.assert_any_call(mock_runtime1.stop)
+        mock_run_on_event_loop.assert_any_call(mock_runtime2.stop)
+# Removed syntax error.

--- a/tsercom/runtime/server/server_runtime_data_handler_unittest.py
+++ b/tsercom/runtime/server/server_runtime_data_handler_unittest.py
@@ -1,0 +1,134 @@
+"""Tests for ServerRuntimeDataHandler."""
+
+import pytest
+from unittest import mock
+
+from tsercom.runtime.server.server_runtime_data_handler import ServerRuntimeDataHandler
+from tsercom.data.remote_data_reader import RemoteDataReader
+from tsercom.data.annotated_instance import AnnotatedInstance # For type hint
+from tsercom.data.serializable_annotated_instance import SerializableAnnotatedInstance # For type hint
+from tsercom.threading.async_poller import AsyncPoller
+from tsercom.timesync.server.time_sync_server import TimeSyncServer
+from tsercom.runtime.id_tracker import IdTracker
+from tsercom.runtime.endpoint_data_processor import EndpointDataProcessor
+from tsercom.caller_id.caller_identifier import CallerIdentifier
+from tsercom.timesync.common.synchronized_clock import SynchronizedClock
+from tsercom.threading.thread_watcher import ThreadWatcher 
+
+
+class TestServerRuntimeDataHandler:
+    """Tests for the ServerRuntimeDataHandler class."""
+
+    @pytest.fixture
+    def mock_thread_watcher(self):
+        return mock.Mock(spec=ThreadWatcher)
+
+    @pytest.fixture
+    def mock_data_reader(self):
+        return mock.Mock(spec=RemoteDataReader)
+
+    @pytest.fixture
+    def mock_event_source_poller(self):
+        return mock.Mock(spec=AsyncPoller)
+
+    @pytest.fixture
+    def mock_time_sync_server_instance(self):
+        mock_server = mock.Mock(spec=TimeSyncServer)
+        mock_server.get_synchronized_clock.return_value = mock.Mock(spec=SynchronizedClock)
+        return mock_server
+
+    @pytest.fixture
+    def mock_id_tracker_instance(self):
+        return mock.Mock(spec=IdTracker) 
+    
+    @pytest.fixture
+    def mock_endpoint_data_processor(self):
+        return mock.Mock(spec=EndpointDataProcessor)
+
+    @pytest.fixture
+    def handler(self, mock_data_reader, mock_event_source_poller, 
+                mock_time_sync_server_instance, mock_id_tracker_instance):
+        with mock.patch('tsercom.runtime.server.server_runtime_data_handler.TimeSyncServer', return_value=mock_time_sync_server_instance) as mock_ts_server_class, \
+             mock.patch('tsercom.runtime.server.server_runtime_data_handler.IdTracker', return_value=mock_id_tracker_instance) as mock_id_tracker_class:
+            
+            handler_instance = ServerRuntimeDataHandler(
+                data_reader=mock_data_reader,
+                event_source=mock_event_source_poller
+            )
+            handler_instance._mock_ts_server_class = mock_ts_server_class
+            handler_instance._mock_id_tracker_class = mock_id_tracker_class
+            handler_instance._mock_time_sync_server_instance = mock_time_sync_server_instance
+            handler_instance._mock_id_tracker_instance = mock_id_tracker_instance
+            return handler_instance
+
+    def test_init(self, handler, mock_data_reader, mock_event_source_poller): 
+        handler._mock_ts_server_class.assert_called_once_with() 
+        handler._mock_time_sync_server_instance.start_async.assert_called_once()
+        handler._mock_time_sync_server_instance.get_synchronized_clock.assert_called_once()
+        assert handler._ServerRuntimeDataHandler__clock == handler._mock_time_sync_server_instance.get_synchronized_clock.return_value
+
+        handler._mock_id_tracker_class.assert_called_once()
+        assert handler._ServerRuntimeDataHandler__id_tracker == handler._mock_id_tracker_instance
+        
+        assert handler._RuntimeDataHandlerBase__data_reader == mock_data_reader
+        assert handler._RuntimeDataHandlerBase__event_source == mock_event_source_poller
+
+    def test_register_caller(self, handler, mock_endpoint_data_processor):
+        mock_caller_id = CallerIdentifier.random()
+        mock_endpoint = "192.168.1.100"
+        mock_port = 12345
+        
+        expected_clock = handler._ServerRuntimeDataHandler__clock
+
+        with mock.patch.object(handler, '_create_data_processor', return_value=mock_endpoint_data_processor) as mock_create_dp:
+            returned_processor = handler._register_caller(mock_caller_id, mock_endpoint, mock_port)
+
+        handler._mock_id_tracker_instance.add.assert_called_once_with(mock_caller_id, mock_endpoint, mock_port)
+        mock_create_dp.assert_called_once_with(mock_caller_id, expected_clock)
+        assert returned_processor == mock_endpoint_data_processor
+        
+        if hasattr(handler._mock_time_sync_server_instance, 'on_connect'): 
+            handler._mock_time_sync_server_instance.on_connect.assert_not_called()
+
+
+    def test_unregister_caller(self, handler):
+        mock_caller_id = CallerIdentifier.random()
+        
+        try:
+            handler._unregister_caller(mock_caller_id)
+        except Exception as e:
+            pytest.fail(f"_unregister_caller raised an exception unexpectedly: {e}")
+
+        handler._mock_id_tracker_instance.add.assert_not_called()
+        handler._mock_id_tracker_instance.get.assert_not_called()
+        handler._mock_id_tracker_instance.try_get.assert_not_called()
+        handler._mock_id_tracker_instance.has_id.assert_not_called()
+        handler._mock_id_tracker_instance.has_address.assert_not_called()
+
+        if hasattr(handler._mock_time_sync_server_instance, 'on_disconnect'): 
+             handler._mock_time_sync_server_instance.on_disconnect.assert_not_called()
+
+
+    def test_try_get_caller_id(self, handler):
+        mock_endpoint = "10.0.0.1"
+        mock_port = 8080
+        expected_caller_id = CallerIdentifier.random()
+        
+        handler._mock_id_tracker_instance.try_get.return_value = expected_caller_id
+        
+        returned_caller_id = handler._try_get_caller_id(mock_endpoint, mock_port)
+        
+        handler._mock_id_tracker_instance.try_get.assert_called_once_with(mock_endpoint, mock_port)
+        assert returned_caller_id == expected_caller_id
+
+    def test_try_get_caller_id_not_found(self, handler):
+        mock_endpoint = "10.0.0.2"
+        mock_port = 8081
+        
+        handler._mock_id_tracker_instance.try_get.return_value = None 
+        
+        returned_caller_id = handler._try_get_caller_id(mock_endpoint, mock_port)
+        
+        handler._mock_id_tracker_instance.try_get.assert_called_once_with(mock_endpoint, mock_port)
+        assert returned_caller_id is None
+# Removed final syntax error.


### PR DESCRIPTION
This commit introduces unit tests for key components within the tsercom.runtime module, significantly improving code coverage and reliability.

I added tests for the following files:
- tsercom/runtime/id_tracker.py
- tsercom/runtime/runtime_config.py
- tsercom/runtime/client/timesync_tracker.py
- tsercom/runtime/client/client_runtime_data_handler.py
- tsercom/runtime/server/server_runtime_data_handler.py
- tsercom/runtime/runtime_main.py

Key achievements during test development:
- I identified and fixed a bug in IdTracker.try_get().
- I identified and fixed bugs related to dictionary initialization and tuple immutability in TimeSyncTracker.
- I addressed a circular import issue in tsercom/api/runtime_manager.py by localizing imports.
- I ensured all new tests pass successfully.

The following dependencies were found to be necessary and were installed by the test environment: psutil, grpcio, googleapis-common-protos, grpcio-status, zeroconf, ntplib. This suggests they might need to be formally added to the project's dependency management if not already present.