### PR TITLE
feat: Add CI workflow with pytest, coverage, and Codecov

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,36 @@
+name: Python Tests and Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11' # Using a recent stable version
+    - name: Install dependencies
+      run: |
+        pip install -e .[dev]
+        pip install pytest-timeout pytest-cov
+        # Ensure torch is CPU only if it's a dependency.
+        # The following line is a common way to reinstall torch for CPU.
+        # Adjust if tsercom's specific torch version needs a different command.
+        # If torch is not a direct or indirect dependency, this line might not be necessary
+        # or could be removed if it causes issues.
+        pip uninstall torch torchvision torchaudio -y || true # Attempt to remove existing GPU versions
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu # Install CPU versions
+    - name: Run pytest with coverage
+      run: |
+        pytest --cov=tsercom --cov-report=xml --timeout=30
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: rwkeane/tsercom

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Status & Coverage
+
+[![CI Tests](https://github.com/rwkeane/tsercom/actions/workflows/python-tests.yml/badge.svg)](https://github.com/rwkeane/tsercom/actions/workflows/python-tests.yml)
+[![codecov](https://codecov.io/gh/rwkeane/tsercom/branch/main/graph/badge.svg)](https://codecov.io/gh/rwkeane/tsercom)
+
+Code coverage reports are automatically generated on each push via GitHub Actions and uploaded to [Codecov](https://app.codecov.io/gh/rwkeane/tsercom).
+
 # TSERCOM
 ## Time SERies COMmunication
 


### PR DESCRIPTION
Integrates automated testing and live code coverage reporting.

Key changes:
- Creates a GitHub Actions workflow (`.github/workflows/python-tests.yml`):
    - Runs on push/pull_request to `main`.
    - Sets up Python 3.11.
    - Installs dependencies using `pip install -e .[dev]`.
    - Installs `pytest-timeout` and `pytest-cov`.
    - Includes steps to ensure PyTorch (if present as a transitive dependency) is CPU-only.
    - Runs `pytest --cov=tsercom --cov-report=xml --timeout=30`.
    - Uploads coverage reports to Codecov using `codecov/codecov-action@v4` with the slug `rwkeane/tsercom`. (Requires `CODECOV_TOKEN` secret).
- Updates `README.md`:
    - Adds a "Status & Coverage" section at the top.
    - Includes a GitHub Actions CI status badge.
    - Includes a Codecov dynamic coverage badge for the `main` branch.
    - Provides a link to the Codecov reports page.