### PR TITLE
Fix: Implement robust shutdown for RuntimeManager and address e2e tes…

### DIFF
--- a/tsercom/api/split_process/split_process_error_watcher_source.py
+++ b/tsercom/api/split_process/split_process_error_watcher_source.py
@@ -70,8 +70,15 @@ class SplitProcessErrorWatcherSource:
             RuntimeError: If `stop` is called when the source is not currently running.
         """
         self.__is_running.stop()  # Will raise RuntimeError if not running.
+        if self.__thread is not None: # Check if thread exists
+            self.__thread.join(timeout=2.0) # Join with a timeout
+            if self.__thread.is_alive():
+                # Optionally log if still alive, though it should exit as __is_running is False
+                # print(f"SplitProcessErrorWatcherSource: Polling thread {self.__thread.name} did not join in time.", file=sys.stderr)
+                pass # For now, no print in library code without proper logging
         # Note: Consider joining self.__thread here if immediate cleanup is critical,
         # though IsRunningTracker pattern usually means the thread exits cleanly.
+        # The above comment is now addressed by the join.
 
     def is_running(self) -> bool:
         """Checks if the error watcher source is currently polling for exceptions.

--- a/tsercom/runtime_e2etest.py
+++ b/tsercom/runtime_e2etest.py
@@ -66,10 +66,7 @@ class FakeRuntime(Runtime):
         )
 
         data = FakeData(started)
-        try:
-            await self.__responder.process_data(data, start_timestamp)
-        except Exception:
-            pass
+        await self.__responder.process_data(data, start_timestamp)
 
     async def stop(self) -> None:
         assert self.__responder is not None
@@ -159,9 +156,10 @@ class FaultyCreateRuntimeInitializer(RuntimeInitializer):
 
 def __check_initialization(init_call: Callable[[RuntimeManager], None]):
     runtime_manager = RuntimeManager(is_testing=True)
-    runtime_manager.check_for_exception()
-    runtime_future = runtime_manager.register_runtime_initializer(
-        FakeRuntimeInitializer(service_type="Client")
+    try:
+        runtime_manager.check_for_exception()
+        runtime_future = runtime_manager.register_runtime_initializer(
+            FakeRuntimeInitializer(service_type="Client")
     )
 
     assert not runtime_future.done()
@@ -232,6 +230,8 @@ def __check_initialization(init_call: Callable[[RuntimeManager], None]):
     assert not data_aggregator.has_new_data(
         test_id
     ), f"Aggregator should not have new data for test_id ({test_id}) after get_new_data for stop"
+    finally:
+        runtime_manager.shutdown()
 
 
 def test_out_of_process_init():


### PR DESCRIPTION
…t hangs.

This change introduces a `shutdown()` method in `RuntimeManager` to ensure proper termination of out-of-process runtimes. The `shutdown()` method:
- Stops the `SplitProcessErrorWatcherSource`.
- Attempts to `terminate()` the child process.
- If termination is unsuccessful, escalates to `kill()` the child process.
- Joins the process to ensure cleanup.

This is intended to resolve hangs in `tsercom/runtime_e2etest.py` where the child process managed by `RuntimeManager` would not exit cleanly because `remote_process_main` was designed to run until an internal exception.

Additionally, a `try/except pass` in `FakeRuntime.start_async` within your e2e tests was removed to prevent silent error swallowing.

Verification of the fix was hindered by timeouts in the test execution environment, preventing confirmation that all tests pass as expected. These changes represent a logical resolution to the hypothesized cause of the hangs.