### PR TITLE
I've added unit tests for `tsercom/util` and `tsercom/timesync`.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev1+gc3e36ea.d20250531"
+__version__ = "0.1.dev2+gf58adeb.d20250531"

--- a/tsercom/timesync/client/client_synchronized_clock_unittest.py
+++ b/tsercom/timesync/client/client_synchronized_clock_unittest.py
@@ -1,0 +1,178 @@
+"""Tests for ClientSynchronizedClock."""
+
+import datetime
+import pytest
+
+from tsercom.timesync.client.client_synchronized_clock import (
+    ClientSynchronizedClock,
+)
+from tsercom.timesync.common.synchronized_timestamp import (
+    SynchronizedTimestamp,
+)
+
+
+# --- Tests for ClientSynchronizedClock.Client ABC ---
+
+
+class GoodClientImpl(ClientSynchronizedClock.Client):
+    """A concrete implementation of ClientSynchronizedClock.Client."""
+
+    def get_offset_seconds(self) -> float:
+        return 0.0
+
+
+class BadClientImpl(ClientSynchronizedClock.Client):
+    """Implementation missing get_offset_seconds."""
+
+    pass
+
+
+def test_good_client_impl_instantiation():
+    """Tests that a class correctly implementing Client can be instantiated."""
+    try:
+        client = GoodClientImpl()
+        assert isinstance(client, ClientSynchronizedClock.Client)
+    except TypeError:
+        pytest.fail(
+            "GoodClientImpl instantiation raised TypeError unexpectedly."
+        )
+
+
+def test_bad_client_impl_instantiation():
+    """Tests that a class missing get_offset_seconds cannot be instantiated."""
+    with pytest.raises(
+        TypeError,
+        match="Can't instantiate abstract class BadClientImpl with abstract method get_offset_seconds",
+    ):
+        BadClientImpl()
+
+
+# --- Tests for ClientSynchronizedClock ---
+
+
+@pytest.fixture
+def mock_client(mocker) -> ClientSynchronizedClock.Client:
+    """Fixture to create a MagicMock instance of ClientSynchronizedClock.Client."""
+    return mocker.MagicMock(spec=ClientSynchronizedClock.Client)
+
+
+@pytest.fixture
+def clock(
+    mock_client: ClientSynchronizedClock.Client,
+) -> ClientSynchronizedClock:
+    """Fixture to create a ClientSynchronizedClock with a mock client."""
+    return ClientSynchronizedClock(mock_client)
+
+
+def test_init_with_client(mock_client: ClientSynchronizedClock.Client):
+    """Tests instantiation of ClientSynchronizedClock with a client."""
+    try:
+        csc = ClientSynchronizedClock(mock_client)
+        # Access the name-mangled attribute to verify it was stored
+        assert (
+            csc._ClientSynchronizedClock__client is mock_client
+        )  # pyright: ignore[reportPrivateUsage]
+    except Exception as e:
+        pytest.fail(f"ClientSynchronizedClock instantiation failed: {e}")
+
+
+# Base datetime for sync/desync tests
+BASE_DT = datetime.datetime(2023, 1, 1, 12, 0, 0)
+
+
+def test_sync_positive_offset(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests sync with a positive offset."""
+    mock_client.get_offset_seconds.return_value = 10.0
+    synced_ts = clock.sync(BASE_DT)
+    expected_dt = BASE_DT + datetime.timedelta(seconds=10.0)
+    assert synced_ts.as_datetime() == expected_dt
+
+
+def test_sync_negative_offset(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests sync with a negative offset."""
+    mock_client.get_offset_seconds.return_value = -5.0
+    synced_ts = clock.sync(BASE_DT)
+    expected_dt = BASE_DT - datetime.timedelta(seconds=5.0)
+    assert synced_ts.as_datetime() == expected_dt
+
+
+def test_sync_zero_offset(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests sync with a zero offset."""
+    mock_client.get_offset_seconds.return_value = 0.0
+    synced_ts = clock.sync(BASE_DT)
+    assert synced_ts.as_datetime() == BASE_DT
+
+
+def test_desync_positive_offset(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests desync with a positive offset (client ahead of server)."""
+    mock_client.get_offset_seconds.return_value = 10.0
+    server_dt = BASE_DT + datetime.timedelta(
+        seconds=10.0
+    )  # Synchronized time is ahead
+    synced_ts = SynchronizedTimestamp(server_dt)
+    local_dt = clock.desync(synced_ts)
+    assert local_dt == BASE_DT
+
+
+def test_desync_negative_offset(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests desync with a negative offset (client behind server)."""
+    mock_client.get_offset_seconds.return_value = -5.0
+    server_dt = BASE_DT - datetime.timedelta(
+        seconds=5.0
+    )  # Synchronized time is behind
+    synced_ts = SynchronizedTimestamp(server_dt)
+    local_dt = clock.desync(synced_ts)
+    assert local_dt == BASE_DT
+
+
+def test_desync_zero_offset(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests desync with a zero offset."""
+    mock_client.get_offset_seconds.return_value = 0.0
+    server_dt = BASE_DT
+    synced_ts = SynchronizedTimestamp(server_dt)
+    local_dt = clock.desync(synced_ts)
+    assert local_dt == server_dt
+
+
+def test_now_property(
+    clock: ClientSynchronizedClock, mock_client: ClientSynchronizedClock.Client
+):
+    """Tests the 'now' property."""
+    offset_seconds = 15.0
+    mock_client.get_offset_seconds.return_value = offset_seconds
+
+    # Approximate expected synchronized time
+    time_before_sync = datetime.datetime.now() + datetime.timedelta(
+        seconds=offset_seconds
+    )
+    client_now_ts = clock.now
+    time_after_sync = datetime.datetime.now() + datetime.timedelta(
+        seconds=offset_seconds
+    )
+
+    assert isinstance(client_now_ts, SynchronizedTimestamp)
+    synced_dt = client_now_ts.as_datetime()
+
+    # Allow a small tolerance for processing time
+    # Note: datetime.now() is naive, and ClientSynchronizedClock produces naive UTC-equivalent
+    # if the input to sync() is naive (which datetime.now() is).
+    # The comparison should be between naive datetimes.
+    assert synced_dt >= time_before_sync - datetime.timedelta(
+        microseconds=10000
+    )  # Allow 10ms before
+    assert synced_dt <= time_after_sync + datetime.timedelta(
+        microseconds=10000
+    )  # Allow 10ms after
+    assert synced_dt.tzinfo is None  # Should be naive

--- a/tsercom/timesync/client/fake_time_sync_client_unittest.py
+++ b/tsercom/timesync/client/fake_time_sync_client_unittest.py
@@ -1,0 +1,149 @@
+"""Tests for FakeTimeSyncClient."""
+
+import pytest
+import threading
+import time
+
+from tsercom.threading.thread_watcher import ThreadWatcher
+from tsercom.timesync.client.fake_time_sync_client import FakeTimeSyncClient
+from tsercom.timesync.client.client_synchronized_clock import (
+    ClientSynchronizedClock,
+)
+
+
+@pytest.fixture
+def mock_watcher(mocker) -> ThreadWatcher:
+    """Fixture for a mocked ThreadWatcher."""
+    return mocker.MagicMock(spec=ThreadWatcher)
+
+
+@pytest.fixture
+def client(mock_watcher: ThreadWatcher) -> FakeTimeSyncClient:
+    """Fixture for a FakeTimeSyncClient instance."""
+    # Use dummy values for server_ip and ntp_port as they are not used by FakeTimeSyncClient
+    return FakeTimeSyncClient(mock_watcher, "127.0.0.1", 123)
+
+
+def test_init(client: FakeTimeSyncClient):
+    """Tests basic initialization of FakeTimeSyncClient."""
+    assert not client.is_running()
+    assert (
+        not client._FakeTimeSyncClient__start_barrier.is_set()
+    )  # pyright: ignore[reportPrivateUsage]
+    assert (
+        len(client._FakeTimeSyncClient__time_offsets) == 0
+    )  # pyright: ignore[reportPrivateUsage]
+
+
+def test_start_async(client: FakeTimeSyncClient):
+    """Tests the start_async method."""
+    client.start_async()
+    assert client.is_running()
+    assert (
+        client._FakeTimeSyncClient__start_barrier.is_set()
+    )  # pyright: ignore[reportPrivateUsage]
+    # Compare content by converting deque to list
+    assert list(client._FakeTimeSyncClient__time_offsets) == [
+        0.0
+    ]  # pyright: ignore[reportPrivateUsage]
+
+    # Test calling start_async() again when already running
+    with pytest.raises(AssertionError, match="Client is already running."):
+        client.start_async()
+
+    # Cleanup
+    client.stop()
+
+
+def test_stop(client: FakeTimeSyncClient):
+    """Tests the stop method."""
+    client.start_async()  # Must be running to stop
+    assert client.is_running()
+
+    client.stop()
+    assert not client.is_running()
+    assert (
+        not client._FakeTimeSyncClient__start_barrier.is_set()
+    )  # pyright: ignore[reportPrivateUsage]
+
+    # Test calling stop() again when already stopped (should be a no-op)
+    try:
+        client.stop()
+    except Exception as e:
+        pytest.fail(
+            f"Calling stop() on an already stopped client raised an error: {e}"
+        )
+
+
+def test_is_running(client: FakeTimeSyncClient):
+    """Tests the is_running method reflects the correct state."""
+    assert not client.is_running()  # Initial state
+    client.start_async()
+    assert client.is_running()
+    client.stop()
+    assert not client.is_running()
+
+
+def test_get_offset_seconds_blocks_if_not_started(client: FakeTimeSyncClient):
+    """Tests that get_offset_seconds blocks until the client is started."""
+    result = []  # To store result from the thread
+
+    def target():
+        result.append(client.get_offset_seconds())
+
+    thread = threading.Thread(target=target)
+    thread.start()
+
+    # Assert the thread is alive (blocked) for a short period
+    time.sleep(0.1)  # Give some time for the thread to block on the barrier
+    assert thread.is_alive()
+    assert not result  # Result list should be empty as thread is blocked
+
+    # Start the client to unblock the thread
+    client.start_async()
+    thread.join(timeout=1.0)  # Wait for the thread to complete
+
+    assert not thread.is_alive()  # Thread should have finished
+    assert result == [0.0]
+
+    # Cleanup
+    client.stop()
+
+
+def test_get_offset_seconds_returns_offset_after_started(
+    client: FakeTimeSyncClient,
+):
+    """Tests that get_offset_seconds returns the offset once started."""
+    client.start_async()
+    assert client.get_offset_seconds() == 0.0
+    # Cleanup
+    client.stop()
+
+
+def test_get_offset_seconds_deque_empty_assertion(client: FakeTimeSyncClient):
+    """
+    Tests assertion if the time_offsets deque is empty after start
+    (an unlikely edge case for FakeTimeSyncClient unless manipulated).
+    """
+    client.start_async()
+    # Manually clear the deque after start_async populated it
+    client._FakeTimeSyncClient__time_offsets.clear()  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(
+        AssertionError,
+        match="Time offsets deque should not be empty after start.",
+    ):
+        client.get_offset_seconds()
+
+    # Cleanup
+    client.stop()
+
+
+def test_get_synchronized_clock(client: FakeTimeSyncClient):
+    """Tests the get_synchronized_clock method."""
+    sync_clock = client.get_synchronized_clock()
+    assert isinstance(sync_clock, ClientSynchronizedClock)
+    # Check if the client instance within the clock is the FakeTimeSyncClient itself
+    assert (
+        sync_clock._ClientSynchronizedClock__client is client
+    )  # pyright: ignore[reportPrivateUsage]

--- a/tsercom/timesync/client/time_sync_client_unittest.py
+++ b/tsercom/timesync/client/time_sync_client_unittest.py
@@ -3,23 +3,24 @@
 import pytest
 import time
 import threading
+import logging
+from unittest.mock import MagicMock
 
-import ntplib  # For NTPException
+import ntplib
 
 from tsercom.timesync.client.time_sync_client import TimeSyncClient
 from tsercom.threading.thread_watcher import ThreadWatcher
+from tsercom.timesync.common.constants import kNtpVersion
+from tsercom.timesync.client.client_synchronized_clock import (
+    ClientSynchronizedClock,
+)
 
 
 @pytest.fixture
 def mock_thread_watcher_fixture(mocker):
     watcher = mocker.MagicMock(spec=ThreadWatcher)
-    # If create_tracked_thread is called, make it just run the target directly
-    # for simplicity in testing the client's logic, not the watcher's.
-    # However, for thread joining, we might need a real thread or a more sophisticated mock.
-    # For now, let's assume direct execution or a simple thread.
 
     def create_thread_side_effect(target, *args, **kwargs):
-        # For tests that need the loop to run and then stop, a real thread is better.
         thread = threading.Thread(
             target=target, args=args, kwargs=kwargs, daemon=True
         )
@@ -31,36 +32,43 @@ def mock_thread_watcher_fixture(mocker):
     return watcher
 
 
+@pytest.fixture
+def mock_ntp_client_fixture(mocker):
+    """Fixture to mock ntplib.NTPClient."""
+    MockNTPClient = mocker.patch(
+        "tsercom.timesync.client.time_sync_client.ntplib.NTPClient"
+    )
+    mock_instance = MockNTPClient.return_value
+    # Ensure that the mock_instance.request itself is a mock if it's going to be called
+    if not isinstance(mock_instance.request, MagicMock):
+        mock_instance.request = MagicMock()
+    return mock_instance
+
+
+@pytest.fixture
+def mock_time_sleep_fixture(mocker):
+    """Fixture to mock time.sleep to prevent actual sleeping in tests."""
+    return mocker.patch(
+        "tsercom.timesync.client.time_sync_client.time.sleep",
+        return_value=None,
+    )
+
+
 class TestTimeSyncClientNTPFailures:
     """Tests TimeSyncClient behavior when NTP requests consistently fail."""
 
+    @pytest.mark.usefixtures(
+        "mock_ntp_client_fixture", "mock_time_sleep_fixture"
+    )
     def test_start_barrier_not_set_and_no_offsets_if_ntp_fails_consistently(
-        self, mock_thread_watcher_fixture, mocker
+        self, mock_thread_watcher_fixture, mock_ntp_client_fixture
     ):
-        """
-        Test that __start_barrier is not set and no fake offsets are added
-        if NTP requests always fail.
-        """
-        MockNTPClient = mocker.patch(
-            "tsercom.timesync.client.time_sync_client.ntplib.NTPClient"
-        )
-        # Configure NTPClient mock to always raise NTPException on request
-        mock_ntp_instance = MockNTPClient.return_value
-        mock_ntp_instance.request.side_effect = ntplib.NTPException(
+        mock_ntp_client_fixture.request.side_effect = ntplib.NTPException(
             "Mock NTP failure"
         )
-
         client = TimeSyncClient(mock_thread_watcher_fixture, "dummy_server_ip")
         client.start_async()
-
-        # Allow some time for the sync loop to run and attempt NTP requests.
-        # The loop has a 3-second sleep, so we need to wait less than that to catch
-        # it before it would successfully get an offset (if it could).
-        # We also need to ensure it tries at least once.
-        # To make this test faster and more deterministic, we could mock time.sleep
-        # in __run_sync_loop, but that's more involved.
-        # For now, assume the first request attempt happens quickly.
-        time.sleep(0.1)  # Give a little time for the loop to start and try.
+        time.sleep(0.01)
 
         assert (
             not client._TimeSyncClient__start_barrier.is_set()
@@ -69,51 +77,30 @@ class TestTimeSyncClientNTPFailures:
             len(client._TimeSyncClient__time_offsets) == 0
         ), "Time offsets should be empty if NTP requests fail."
 
-        client.stop()  # Clean up the client's thread
-        # Wait for the thread to actually join
-        if client._TimeSyncClient__sync_loop_thread is not None:
-            client._TimeSyncClient__sync_loop_thread.join(timeout=1.0)
+        client.stop()
+        sync_thread = getattr(
+            client, "_TimeSyncClient__sync_loop_thread", None
+        )
+        if sync_thread is not None and sync_thread.is_alive():
+            sync_thread.join(timeout=0.5)
 
+    @pytest.mark.usefixtures(
+        "mock_ntp_client_fixture", "mock_time_sleep_fixture"
+    )
     def test_get_offset_seconds_blocks_when_barrier_not_set(
-        self, mock_thread_watcher_fixture, mocker
+        self, mock_thread_watcher_fixture, mock_ntp_client_fixture
     ):
-        """
-        Test that get_offset_seconds blocks (does not return quickly)
-        if the start barrier is not set due to NTP failures.
-        """
-        MockNTPClient = mocker.patch(
-            "tsercom.timesync.client.time_sync_client.ntplib.NTPClient"
-        )
-        mock_time_sleep = mocker.patch(
-            "tsercom.timesync.client.time_sync_client.time.sleep"
-        )
-        mock_ntp_instance = MockNTPClient.return_value
-        mock_ntp_instance.request.side_effect = ntplib.NTPException(
+        mock_ntp_client_fixture.request.side_effect = ntplib.NTPException(
             "Mock NTP failure"
         )
-
-        # Make time.sleep do nothing to speed up the loop for testing
-        mock_time_sleep.return_value = None
-
         client = TimeSyncClient(mock_thread_watcher_fixture, "dummy_server_ip")
         client.start_async()
-
-        # Let the client loop run a few times (mocked sleep makes this fast)
-        for _ in range(5):
-            if client._TimeSyncClient__start_barrier.is_set():
-                break  # Should not happen in this test
-            time.sleep(
-                0.001
-            )  # Tiny sleep to allow context switching if loop is very tight
+        time.sleep(0.01)
 
         assert (
             not client._TimeSyncClient__start_barrier.is_set()
         ), "Pre-condition: Start barrier should not be set."
-        assert (
-            len(client._TimeSyncClient__time_offsets) == 0
-        ), "Pre-condition: Time offsets should be empty."
 
-        # Call get_offset_seconds in a separate thread
         offset_result = []
         exception_result = []
 
@@ -124,61 +111,33 @@ class TestTimeSyncClientNTPFailures:
             except Exception as e:
                 exception_result.append(e)
 
-        thread = threading.Thread(target=target_get_offset)
-        thread.daemon = True  # So it doesn't block test exit
+        thread = threading.Thread(target=target_get_offset, daemon=True)
         thread.start()
-
-        # Check that it's blocking
-        thread.join(timeout=0.2)  # Give it a moment to potentially return
+        thread.join(timeout=0.2)
         assert thread.is_alive(), "get_offset_seconds should be blocking."
 
-        # Clean up
         client.stop()
-        thread.join(timeout=1.0)  # Now it should exit after client.stop()
-
+        thread.join(timeout=0.5)
         assert (
             not offset_result
         ), "get_offset_seconds should not have returned a value."
-        # Depending on how stop() affects a blocked get_offset_seconds,
-        # an exception might be raised (e.g., AssertionError if __time_offsets is empty).
-        # This test primarily cares that it blocked *before* stop().
         if exception_result:
-            # This is acceptable if stop() causes the wait on barrier to break and then an assert fails
             assert isinstance(
-                exception_result[0], AssertionError
-            ) or isinstance(
-                exception_result[0], RuntimeError
+                exception_result[0], (AssertionError, RuntimeError)
             ), f"Unexpected exception: {exception_result[0]}"
-            print(
-                f"get_offset_seconds raised {type(exception_result[0])} after stop, which is acceptable."
-            )
 
-        # Final check on barrier state after stop
-        # Depending on stop logic, barrier might be set or not. Not the primary focus.
-        # print(f"Barrier state after stop: {client._TimeSyncClient__start_barrier.is_set()}")
-
+    @pytest.mark.usefixtures(
+        "mock_ntp_client_fixture", "mock_time_sleep_fixture"
+    )
     def test_barrier_set_and_offset_available_on_successful_ntp_request(
-        self, mock_thread_watcher_fixture, mocker
+        self, mock_thread_watcher_fixture, mock_ntp_client_fixture
     ):
-        """Test that the barrier is set and offset is available after a successful NTP request."""
-        MockNTPClient = mocker.patch(
-            "tsercom.timesync.client.time_sync_client.ntplib.NTPClient"
-        )
-        mock_ntp_instance = MockNTPClient.return_value
-        mock_response = mocker.MagicMock()
-        mock_response.offset = 0.123  # Example offset
-        mock_ntp_instance.request.return_value = mock_response
-
+        mock_response = MagicMock()
+        mock_response.offset = 0.123
+        mock_ntp_client_fixture.request.return_value = mock_response
         client = TimeSyncClient(mock_thread_watcher_fixture, "dummy_server_ip")
         client.start_async()
-
-        # Wait for the barrier to be set. This might take up to kOffsetFrequencySeconds (3s)
-        # in the worst case in the original code. For a test, we want it faster.
-        # We can wait on the barrier itself with a timeout.
-        barrier_set = client._TimeSyncClient__start_barrier.wait(
-            timeout=1.0
-        )  # Adjust timeout as needed
-
+        barrier_set = client._TimeSyncClient__start_barrier.wait(timeout=1.0)
         assert (
             barrier_set
         ), "Start barrier should be set after successful NTP request."
@@ -186,10 +145,334 @@ class TestTimeSyncClientNTPFailures:
             len(client._TimeSyncClient__time_offsets) > 0
         ), "Time offsets should not be empty after successful NTP request."
         assert client._TimeSyncClient__time_offsets[0] == 0.123
-
-        # Check get_offset_seconds returns the value
         assert client.get_offset_seconds() == 0.123
+        client.stop()
+        sync_thread = getattr(
+            client, "_TimeSyncClient__sync_loop_thread", None
+        )
+        if sync_thread is not None and sync_thread.is_alive():
+            sync_thread.join(timeout=0.5)
+
+
+# --- New Test Class for Operations ---
+@pytest.mark.usefixtures(
+    "mock_thread_watcher_fixture",
+    "mock_ntp_client_fixture",
+    "mock_time_sleep_fixture",
+)
+class TestTimeSyncClientOperations:
+    """Tests for general operations of TimeSyncClient."""
+
+    @pytest.fixture
+    def client(self, mock_thread_watcher_fixture) -> TimeSyncClient:
+        client_instance = TimeSyncClient(
+            mock_thread_watcher_fixture, "pool.ntp.org", ntp_port=123
+        )
+        yield client_instance
+        if client_instance.is_running():
+            client_instance.stop()
+        sync_thread = getattr(
+            client_instance, "_TimeSyncClient__sync_loop_thread", None
+        )
+        if sync_thread and sync_thread.is_alive():
+            sync_thread.join(timeout=1.0)
+
+    def test_offset_averaging(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        offsets = [0.1, 0.2, 0.3, 0.4, 0.5]
+        mock_ntp_client_fixture.request.side_effect = [
+            MagicMock(offset=o) for o in offsets
+        ]
+        client.start_async()
+        barrier_set = client._TimeSyncClient__start_barrier.wait(timeout=1.0)
+        assert barrier_set, "Start barrier was not set after starting client."
+
+        max_wait_cycles = len(offsets) + 20
+        cycles = 0
+        while (
+            mock_ntp_client_fixture.request.call_count < len(offsets)
+            and cycles < max_wait_cycles
+        ):
+            time.sleep(0.001)
+            cycles += 1
+        assert mock_ntp_client_fixture.request.call_count >= len(
+            offsets
+        ), f"NTP request not called enough. Expected: {len(offsets)}, Got: {mock_ntp_client_fixture.request.call_count}"
+        expected_average = sum(offsets) / len(offsets)
+        assert client.get_offset_seconds() == pytest.approx(expected_average)
+        assert list(client._TimeSyncClient__time_offsets) == offsets
+
+    def test_max_offset_count(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        # Note: kMaxOffsetCount is a local variable within TimeSyncClient.__run_sync_loop.
+        # It's hardcoded to 10 in the source. We test against this known value.
+        # Direct patching of this local variable to a different value (e.g., 3) from
+        # a test is not straightforward without modifying the source code structure.
+        k_max_offset_count_from_source = 10
+        num_offsets_to_send = (
+            12  # Send more than kMaxOffsetCount to test truncation
+        )
+
+        offsets = [0.1 * (i + 1) for i in range(num_offsets_to_send)]
+        mock_ntp_client_fixture.request.side_effect = [
+            MagicMock(offset=o) for o in offsets
+        ]
+        client.start_async()
+        barrier_set = client._TimeSyncClient__start_barrier.wait(timeout=1.0)
+        assert barrier_set, "Start barrier was not set."
+
+        max_wait_cycles = num_offsets_to_send + 20
+        cycles = 0
+        while (
+            mock_ntp_client_fixture.request.call_count < num_offsets_to_send
+            and cycles < max_wait_cycles
+        ):
+            time.sleep(0.001)
+            cycles += 1
+        assert (
+            mock_ntp_client_fixture.request.call_count >= num_offsets_to_send
+        ), f"NTP request not called enough. Expected: {num_offsets_to_send}, Got: {mock_ntp_client_fixture.request.call_count}"
+        expected_stored_offsets = offsets[-k_max_offset_count_from_source:]
+        assert (
+            list(client._TimeSyncClient__time_offsets)
+            == expected_stored_offsets
+        )
+        expected_average = sum(expected_stored_offsets) / len(
+            expected_stored_offsets
+        )
+        assert client.get_offset_seconds() == pytest.approx(expected_average)
+
+    def test_stop_terminates_sync_loop(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        mock_ntp_client_fixture.request.return_value = MagicMock(offset=0.1)
+        client.start_async()
+        sync_loop_thread = client._TimeSyncClient__sync_loop_thread
+        assert sync_loop_thread is not None and sync_loop_thread.is_alive()
+        client.stop()
+        sync_loop_thread.join(timeout=1.0)
+        assert not sync_loop_thread.is_alive()
+
+    def test_get_offset_after_stop(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        mock_ntp_client_fixture.request.return_value = MagicMock(offset=0.123)
+        client.start_async()
+        barrier_set = client._TimeSyncClient__start_barrier.wait(timeout=1.0)
+        assert barrier_set, "Start barrier was not set."
+
+        max_wait_cycles = 5
+        cycles = 0
+        while (
+            mock_ntp_client_fixture.request.call_count < 1
+            and cycles < max_wait_cycles
+        ):
+            time.sleep(0.001)
+            cycles += 1
+        assert (
+            mock_ntp_client_fixture.request.call_count >= 1
+        ), "NTP request was not called."
+
+        first_offset = client.get_offset_seconds()
+        assert first_offset == pytest.approx(0.123)
+        client.stop()
+        assert client.get_offset_seconds() == pytest.approx(first_offset)
+        assert client._TimeSyncClient__start_barrier.is_set()
+
+    def test_assertion_error_in_loop_calls_watcher_and_stops_loop(
+        self,
+        client: TimeSyncClient,
+        mock_ntp_client_fixture,
+        mock_thread_watcher_fixture,
+    ):
+        test_exception = AssertionError("Test assertion in loop")
+        mock_ntp_client_fixture.request.side_effect = test_exception
+        client.start_async()
+        max_wait_cycles = 10
+        cycles = 0
+        while (
+            mock_thread_watcher_fixture.on_exception_seen.call_count == 0
+            and cycles < max_wait_cycles
+        ):
+            time.sleep(0.01)
+            cycles += 1
+        mock_thread_watcher_fixture.on_exception_seen.assert_called_once_with(
+            test_exception
+        )
+        sync_loop_thread = client._TimeSyncClient__sync_loop_thread
+        if sync_loop_thread:
+            sync_loop_thread.join(timeout=1.0)
+            assert (
+                not sync_loop_thread.is_alive()
+            ), "Sync loop thread should be dead."
+        assert (
+            client.is_running()
+        ), "is_running is True as loop crash doesn't call client.stop()."
+        client.stop()
+        assert not client.is_running()
+
+    def test_general_exception_in_loop_logs_and_continues(
+        self, client: TimeSyncClient, mock_ntp_client_fixture, mocker
+    ):
+        mock_logging_error = mocker.patch("logging.error")
+        mock_ok_response = MagicMock(offset=0.25)
+        test_value_error = ValueError("Test value error in loop")
+
+        def request_side_effect_with_default(*args, **kwargs):
+            if mock_ntp_client_fixture.request.call_count == 1:
+                raise test_value_error
+            return mock_ok_response
+
+        mock_ntp_client_fixture.request.side_effect = (
+            request_side_effect_with_default
+        )
+
+        client.start_async()
+        barrier_set = client._TimeSyncClient__start_barrier.wait(timeout=1.0)
+        assert (
+            barrier_set
+        ), "Start barrier was not set, successful response not processed."
+
+        expected_log_message = f"Error during NTP sync: {test_value_error}"
+        call_found = any(
+            expected_log_message == call_arg[0][0]
+            for call_arg in mock_logging_error.call_args_list
+        )
+        assert (
+            call_found
+        ), f"Specific ValueError log ('{expected_log_message}') not found. Logs: {mock_logging_error.call_args_list}"
+
+        specific_error_logs_count = sum(
+            1
+            for call_arg in mock_logging_error.call_args_list
+            if expected_log_message == call_arg[0][0]
+        )
+        assert (
+            specific_error_logs_count == 1
+        ), f"Expected 1 log for the specific ValueError, got {specific_error_logs_count}. Logs: {mock_logging_error.call_args_list}"
+
+        assert client.is_running()
+        assert client.get_offset_seconds() == pytest.approx(0.25)
+        sync_loop_thread = client._TimeSyncClient__sync_loop_thread
+        assert sync_loop_thread and sync_loop_thread.is_alive()
+
+    def test_successful_request_after_initial_failures(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        # Explicitly reset the mock for the request method to ensure clean state
+        mock_ntp_client_fixture.request.reset_mock(
+            return_value=True, side_effect=True
+        )
+
+        mock_ok_response = MagicMock(offset=0.333)
+        # Test with one failure, then one success
+        effects = [ntplib.NTPException("fail1"), mock_ok_response]
+        effects_iter = iter(effects)
+        second_call_done_event = threading.Event()
+
+        # request.call_count is 0 when side_effect is called for the 1st time.
+        # So, for the 2nd call (successful one), request.call_count will be 1.
+        def request_side_effect_limited(*args, **kwargs):
+            current_call_idx = mock_ntp_client_fixture.request.call_count
+            try:
+                effect = next(effects_iter)
+                if isinstance(effect, Exception):
+                    raise effect
+
+                # If this is the 2nd call (index 1) which is the successful one
+                if current_call_idx == 1:
+                    second_call_done_event.set()
+                return effect
+            except StopIteration:
+                # This will be hit on the 3rd call onwards.
+                raise ntplib.NTPException(
+                    "Called more than expected (2 times, test design)."
+                )
+
+        mock_ntp_client_fixture.request.side_effect = (
+            request_side_effect_limited
+        )
+
+        client.start_async()
+
+        # Wait for the second call's side effect to signal completion
+        assert second_call_done_event.wait(
+            timeout=2.0
+        ), "The second NTP call (successful one) did not complete as expected."
+
+        # Give a brief moment for the client thread to process the response.
+        time.sleep(0.01)
 
         client.stop()
-        if client._TimeSyncClient__sync_loop_thread is not None:
-            client._TimeSyncClient__sync_loop_thread.join(timeout=1.0)
+        sync_thread = client._TimeSyncClient__sync_loop_thread
+        if sync_thread and sync_thread.is_alive():
+            sync_thread.join(timeout=1.0)
+
+        assert (
+            client._TimeSyncClient__start_barrier.is_set()
+        ), "Start barrier was not set."
+
+        assert list(client._TimeSyncClient__time_offsets) == [
+            0.333
+        ], f"Expected offsets list [0.333], got: {list(client._TimeSyncClient__time_offsets)}"
+
+        assert client.get_offset_seconds() == pytest.approx(
+            0.333
+        ), "Offset is not the expected 0.333."
+
+        # Total calls should be 2 (one failure, one success)
+        assert (
+            mock_ntp_client_fixture.request.call_count == 2
+        ), f"Expected exactly 2 NTP requests. Got {mock_ntp_client_fixture.request.call_count}"
+
+        assert (
+            not client.is_running()
+        ), "Client should not be running after stop()."
+
+    def test_start_async_already_running(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        mock_ntp_client_fixture.request.return_value = MagicMock(offset=0.1)
+        client.start_async()
+        assert client.is_running()
+        with pytest.raises(
+            AssertionError, match="TimeSyncClient is already running."
+        ):
+            client.start_async()
+
+    def test_get_synchronized_clock(self, client: TimeSyncClient):
+        sync_clock = client.get_synchronized_clock()
+        assert isinstance(sync_clock, ClientSynchronizedClock)
+        assert sync_clock._ClientSynchronizedClock__client is client
+
+    def test_is_running(self, client: TimeSyncClient, mock_ntp_client_fixture):
+        assert not client.is_running()
+        mock_ntp_client_fixture.request.return_value = MagicMock(offset=0.1)
+        client.start_async()
+        assert client.is_running()
+        client.stop()
+        assert not client.is_running()
+
+    def test_ntp_request_uses_configured_version_and_params(
+        self, client: TimeSyncClient, mock_ntp_client_fixture
+    ):
+        mock_ntp_client_fixture.request.return_value = MagicMock(offset=0.1)
+
+        # Reset mock before start to isolate calls for this test
+        mock_ntp_client_fixture.request.reset_mock()
+
+        client.start_async()
+        barrier_set = client._TimeSyncClient__start_barrier.wait(timeout=1.0)
+        assert barrier_set, "Start barrier was not set."
+
+        server_ip_used = client._TimeSyncClient__server_ip
+        ntp_port_used = client._TimeSyncClient__ntp_port
+
+        # Check the first call (or any subsequent call, as parameters should be consistent)
+        mock_ntp_client_fixture.request.assert_any_call(
+            server_ip_used,  # host is positional
+            version=kNtpVersion,
+            port=ntp_port_used,
+        )

--- a/tsercom/timesync/common/fake_synchronized_clock_unittest.py
+++ b/tsercom/timesync/common/fake_synchronized_clock_unittest.py
@@ -1,0 +1,65 @@
+"""Tests for FakeSynchronizedClock."""
+
+import datetime
+import pytest
+
+from tsercom.timesync.common.fake_synchronized_clock import (
+    FakeSynchronizedClock,
+)
+from tsercom.timesync.common.synchronized_timestamp import (
+    SynchronizedTimestamp,
+)
+
+
+@pytest.fixture
+def fake_clock() -> FakeSynchronizedClock:
+    """Fixture to create a FakeSynchronizedClock instance."""
+    return FakeSynchronizedClock()
+
+
+def test_desync(fake_clock: FakeSynchronizedClock):
+    """
+    Tests that desync() returns the original datetime.datetime object
+    from a SynchronizedTimestamp.
+    """
+    original_dt = datetime.datetime(2023, 10, 26, 12, 0, 0)
+    st = SynchronizedTimestamp(original_dt)
+    desynced_dt = fake_clock.desync(st)
+    assert desynced_dt is original_dt
+
+
+def test_sync(fake_clock: FakeSynchronizedClock):
+    """
+    Tests that sync() wraps a datetime.datetime object in a
+    SynchronizedTimestamp.
+    """
+    original_dt = datetime.datetime(2023, 10, 26, 13, 0, 0)
+    synced_st = fake_clock.sync(original_dt)
+
+    assert isinstance(synced_st, SynchronizedTimestamp)
+    assert synced_st.as_datetime() is original_dt
+
+
+def test_now_property(fake_clock: FakeSynchronizedClock):
+    """
+    Tests the now property to ensure it returns a SynchronizedTimestamp
+    wrapping a recent, naive datetime.
+    """
+    # Record time just before calling now
+    time_before = datetime.datetime.now()
+
+    current_st = fake_clock.now
+    assert isinstance(current_st, SynchronizedTimestamp)
+
+    # Record time just after calling now
+    time_after = datetime.datetime.now()
+
+    dt_obj = current_st.as_datetime()
+
+    # Check that the datetime from the clock is between the times recorded
+    # just before and after the call. This allows for minor execution delays.
+    assert dt_obj >= time_before
+    assert dt_obj <= time_after
+
+    # Check that the datetime object is naive (no timezone info)
+    assert dt_obj.tzinfo is None

--- a/tsercom/timesync/common/synchronized_clock_unittest.py
+++ b/tsercom/timesync/common/synchronized_clock_unittest.py
@@ -1,0 +1,117 @@
+"""Tests for the SynchronizedClock ABC."""
+
+import datetime
+import pytest
+from unittest.mock import MagicMock  # For spy return value comparison
+
+from tsercom.timesync.common.synchronized_clock import SynchronizedClock
+from tsercom.timesync.common.synchronized_timestamp import (
+    SynchronizedTimestamp,
+)
+
+
+# --- Test Implementations for ABC Contract ---
+
+
+class GoodClock(SynchronizedClock):
+    """A concrete implementation of SynchronizedClock with all methods."""
+
+    def sync(self, timestamp: datetime.datetime) -> SynchronizedTimestamp:
+        return SynchronizedTimestamp(timestamp)
+
+    def desync(self, time: SynchronizedTimestamp) -> datetime.datetime:
+        return time.as_datetime()
+
+
+class BadClockNoSync(SynchronizedClock):
+    """Implementation missing the 'sync' method."""
+
+    def desync(self, time: SynchronizedTimestamp) -> datetime.datetime:
+        return time.as_datetime()
+
+
+class BadClockNoDesync(SynchronizedClock):
+    """Implementation missing the 'desync' method."""
+
+    def sync(self, timestamp: datetime.datetime) -> SynchronizedTimestamp:
+        return SynchronizedTimestamp(timestamp)
+
+
+class BadClockNoMethods(SynchronizedClock):
+    """Implementation missing all abstract methods."""
+
+    pass
+
+
+def test_good_clock_instantiation():
+    """Tests that a class correctly implementing all abstract methods can be instantiated."""
+    try:
+        clock = GoodClock()
+        assert isinstance(clock, SynchronizedClock)
+    except TypeError:
+        pytest.fail("GoodClock instantiation raised TypeError unexpectedly.")
+
+
+def test_bad_clock_no_sync_instantiation():
+    """Tests that a class missing 'sync' cannot be instantiated."""
+    with pytest.raises(
+        TypeError,
+        match="Can't instantiate abstract class BadClockNoSync with abstract method sync",
+    ):
+        BadClockNoSync()
+
+
+def test_bad_clock_no_desync_instantiation():
+    """Tests that a class missing 'desync' cannot be instantiated."""
+    with pytest.raises(
+        TypeError,
+        match="Can't instantiate abstract class BadClockNoDesync with abstract method desync",
+    ):
+        BadClockNoDesync()
+
+
+def test_bad_clock_no_methods_instantiation():
+    """Tests that a class missing all abstract methods cannot be instantiated."""
+    # The error message might list one or all missing methods depending on Python version/implementation details
+    with pytest.raises(
+        TypeError,
+        match="Can't instantiate abstract class BadClockNoMethods with abstract methods desync, sync",
+    ):
+        BadClockNoMethods()
+
+
+# --- Test for 'now' Property ---
+
+
+def test_now_property_calls_sync(mocker):
+    """Tests that the 'now' property correctly calls the 'sync' method."""
+    clock = GoodClock()
+
+    # Spy on the sync method to check its arguments and return value
+    # We also need to control its return value for assertion
+    expected_synced_time = SynchronizedTimestamp(
+        datetime.datetime.now(tz=datetime.timezone.utc)
+    )
+    mocker.patch.object(clock, "sync", return_value=expected_synced_time)
+
+    time_before = datetime.datetime.now()
+    current_sync_time = clock.now
+    time_after = datetime.datetime.now()
+
+    # Assert that sync was called once
+    clock.sync.assert_called_once()  # type: ignore
+
+    # Check the argument passed to sync
+    call_args = clock.sync.call_args[0]  # type: ignore
+    assert len(call_args) == 1
+    passed_datetime = call_args[0]
+    assert isinstance(passed_datetime, datetime.datetime)
+
+    # The datetime passed to sync should be very close to now()
+    # It should be naive as datetime.datetime.now() is naive.
+    assert passed_datetime >= time_before
+    assert passed_datetime <= time_after
+    assert passed_datetime.tzinfo is None
+
+    # Verify that the result of 'now' is what 'sync' returned
+    assert current_sync_time is expected_synced_time

--- a/tsercom/timesync/common/synchronized_timestamp_unittest.py
+++ b/tsercom/timesync/common/synchronized_timestamp_unittest.py
@@ -1,0 +1,234 @@
+"""Tests for SynchronizedTimestamp."""
+
+import datetime
+
+import pytest
+from google.protobuf import timestamp_pb2
+
+# Corrected import to match how ServerTimestamp is exposed by the package
+from tsercom.timesync.common.proto import (
+    ServerTimestamp,
+)
+from tsercom.timesync.common.synchronized_timestamp import (
+    SynchronizedTimestamp,
+)
+
+
+# A fixed datetime object for consistent tests
+NOW_DATETIME = datetime.datetime.utcnow()  # Naive UTC datetime
+# Per SynchronizedTimestamp docstring, it expects naive datetimes.
+# Let's assume these naive datetimes are implicitly UTC.
+FIXED_DATETIME = datetime.datetime(
+    2023, 10, 26, 12, 0, 0
+)  # Naive, assumed UTC
+
+
+def test_init_valid():
+    """Tests initialization with a valid datetime object."""
+    st = SynchronizedTimestamp(FIXED_DATETIME)
+    assert st.as_datetime() is FIXED_DATETIME
+
+
+def test_init_none():
+    """Tests that an AssertionError is raised if None is passed to __init__."""
+    with pytest.raises(AssertionError, match="Timestamp cannot be None."):
+        SynchronizedTimestamp(None)  # pytype: disable=wrong-arg-types
+
+
+def test_init_invalid_type():
+    """Tests that an AssertionError is raised if an invalid type is passed to __init__."""
+    with pytest.raises(
+        AssertionError, match="Timestamp must be a datetime.datetime object."
+    ):
+        SynchronizedTimestamp(12345)  # pytype: disable=wrong-arg-types
+
+
+def test_as_datetime():
+    """Tests that as_datetime() returns the original datetime object."""
+    st = SynchronizedTimestamp(FIXED_DATETIME)
+    assert st.as_datetime() is FIXED_DATETIME
+
+
+def test_to_grpc_type(mocker):
+    """Tests conversion to the gRPC ServerTimestamp type."""
+    st = SynchronizedTimestamp(FIXED_DATETIME)
+    server_ts = st.to_grpc_type()
+
+    assert isinstance(server_ts, ServerTimestamp)
+    assert isinstance(server_ts.timestamp, timestamp_pb2.Timestamp)
+
+    # Verify that the conversion back from the gRPC Timestamp matches the original datetime.
+    # server_ts.timestamp.ToDatetime() returns a naive datetime representing UTC.
+    # FIXED_DATETIME is now also a naive datetime representing UTC.
+    converted_datetime = server_ts.timestamp.ToDatetime()
+    assert converted_datetime == FIXED_DATETIME
+
+
+# --- Tests for try_parse ---
+
+
+def test_try_parse_none():
+    """Tests try_parse with None input."""
+    assert SynchronizedTimestamp.try_parse(None) is None
+
+
+def test_try_parse_grpc_timestamp(mocker):
+    """Tests try_parse with a valid google.protobuf.timestamp_pb2.Timestamp."""
+    mock_grpc_ts = mocker.MagicMock(spec=timestamp_pb2.Timestamp)
+    expected_datetime = datetime.datetime(2023, 1, 1, 10, 0, 0)
+    mock_grpc_ts.ToDatetime.return_value = expected_datetime
+
+    result = SynchronizedTimestamp.try_parse(mock_grpc_ts)
+    assert isinstance(result, SynchronizedTimestamp)
+    assert result.as_datetime() == expected_datetime
+    mock_grpc_ts.ToDatetime.assert_called_once()
+
+
+def test_try_parse_server_timestamp():
+    """Tests try_parse with a valid ServerTimestamp."""
+    expected_datetime = datetime.datetime(2023, 1, 1, 11, 0, 0)
+
+    # Create a real inner google.protobuf.timestamp_pb2.Timestamp
+    real_inner_ts = timestamp_pb2.Timestamp()
+    real_inner_ts.FromDatetime(expected_datetime)
+
+    # Create the ServerTimestamp wrapper
+    server_ts_wrapper = ServerTimestamp()
+    server_ts_wrapper.timestamp.CopyFrom(
+        real_inner_ts
+    )  # Use CopyFrom for message assignment
+
+    result = SynchronizedTimestamp.try_parse(server_ts_wrapper)
+    assert isinstance(result, SynchronizedTimestamp)
+    assert result.as_datetime() == expected_datetime
+
+
+def test_try_parse_grpc_timestamp_todatetime_value_error(mocker, caplog):
+    """
+    Tests try_parse with a google.protobuf.timestamp_pb2.Timestamp whose
+    ToDatetime() method raises ValueError.
+    """
+    mock_grpc_ts = mocker.MagicMock(spec=timestamp_pb2.Timestamp)
+    mock_grpc_ts.ToDatetime.side_effect = ValueError("Test ToDatetime error")
+
+    result = SynchronizedTimestamp.try_parse(mock_grpc_ts)
+    assert result is None
+    mock_grpc_ts.ToDatetime.assert_called_once()
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert (
+        "Failed to parse gRPC Timestamp to datetime: Test ToDatetime error"
+        in caplog.text
+    )
+
+
+def test_try_parse_invalid_type_raises_assertion_error():
+    """
+    Tests that try_parse raises an AssertionError if an unexpected type
+    (that is not None, Timestamp, or ServerTimestamp) is passed.
+    """
+    with pytest.raises(
+        AssertionError,
+        match="Input must be a google.protobuf.timestamp_pb2.Timestamp or can be resolved to one.",
+    ):
+        SynchronizedTimestamp.try_parse(
+            12345
+        )  # pytype: disable=wrong-arg-types
+
+
+# --- Tests for comparison methods ---
+
+# Create some fixed SynchronizedTimestamp instances for comparison tests
+ST_PAST = SynchronizedTimestamp(FIXED_DATETIME - datetime.timedelta(days=1))
+ST_FIXED = SynchronizedTimestamp(
+    FIXED_DATETIME
+)  # Same as FIXED_DATETIME used in earlier tests
+ST_FUTURE = SynchronizedTimestamp(FIXED_DATETIME + datetime.timedelta(days=1))
+
+# Corresponding datetime objects
+DT_PAST = ST_PAST.as_datetime()
+DT_FIXED = ST_FIXED.as_datetime()
+DT_FUTURE = ST_FUTURE.as_datetime()
+
+
+def test_comparison_st_with_st():
+    """Tests comparison methods between SynchronizedTimestamp instances."""
+    assert ST_FIXED > ST_PAST
+    assert not (ST_FIXED > ST_FUTURE)
+    assert ST_FIXED >= ST_PAST
+    assert ST_FIXED >= ST_FIXED
+    assert not (ST_FIXED >= ST_FUTURE)
+
+    assert ST_FIXED < ST_FUTURE
+    assert not (ST_FIXED < ST_PAST)
+    assert ST_FIXED <= ST_FUTURE
+    assert ST_FIXED <= ST_FIXED
+    assert not (ST_FIXED <= ST_PAST)
+
+    assert ST_FIXED == ST_FIXED
+    assert ST_FIXED == SynchronizedTimestamp(
+        FIXED_DATETIME
+    )  # Different instance, same time
+    assert not (ST_FIXED == ST_PAST)
+
+    assert ST_FIXED != ST_PAST
+    assert not (ST_FIXED != ST_FIXED)
+
+
+def test_comparison_st_with_datetime():
+    """Tests comparison methods between SynchronizedTimestamp and datetime instances."""
+    assert ST_FIXED > DT_PAST
+    assert not (ST_FIXED > DT_FUTURE)
+    assert ST_FIXED >= DT_PAST
+    assert ST_FIXED >= DT_FIXED
+    assert not (ST_FIXED >= DT_FUTURE)
+
+    assert ST_FIXED < DT_FUTURE
+    assert not (ST_FIXED < DT_PAST)
+    assert ST_FIXED <= DT_FUTURE
+    assert ST_FIXED <= DT_FIXED
+    assert not (ST_FIXED <= DT_PAST)
+
+    assert ST_FIXED == DT_FIXED
+    assert not (ST_FIXED == DT_PAST)
+
+    assert ST_FIXED != DT_PAST
+    assert not (ST_FIXED != DT_FIXED)
+
+
+def test_comparison_datetime_with_st():
+    """Tests comparison (equality/inequality) with datetime on the left."""
+    # Note: >, <, >=, <= are not defined if datetime is on the left,
+    # as datetime.__gt__ etc. won't know about SynchronizedTimestamp.
+    # However, __eq__ and __ne__ should work due to Python's fallback mechanism.
+    assert DT_FIXED == ST_FIXED
+    assert not (DT_FIXED == ST_PAST)
+
+    assert DT_FIXED != ST_PAST
+    assert not (DT_FIXED != ST_FIXED)
+
+
+def test_equality_with_other_types():
+    """Tests equality comparison with unrelated types."""
+    assert not (ST_FIXED == "some_string")
+    assert ST_FIXED != "some_string"
+    assert not (ST_FIXED == 12345)
+    assert ST_FIXED != 12345
+    assert not (ST_FIXED == None)  # pylint: disable=singleton-comparison
+    assert ST_FIXED != None  # pylint: disable=singleton-comparison
+
+
+def test_comparison_invalid_type_raises_assertion_error():
+    """
+    Tests that comparison with an unsupported type in >, >=, <, <=
+    raises an AssertionError.
+    """
+    err_match = "Comparison is only supported with SynchronizedTimestamp or datetime.datetime."
+    with pytest.raises(AssertionError, match=err_match):
+        _ = ST_FIXED > "invalid_type"  # type: ignore
+    with pytest.raises(AssertionError, match=err_match):
+        _ = ST_FIXED >= "invalid_type"  # type: ignore
+    with pytest.raises(AssertionError, match=err_match):
+        _ = ST_FIXED < "invalid_type"  # type: ignore
+    with pytest.raises(AssertionError, match=err_match):
+        _ = ST_FIXED <= "invalid_type"  # type: ignore

--- a/tsercom/timesync/server/server_synchronized_clock_unittest.py
+++ b/tsercom/timesync/server/server_synchronized_clock_unittest.py
@@ -1,0 +1,67 @@
+"""Tests for ServerSynchronizedClock."""
+
+import datetime
+import pytest
+
+from tsercom.timesync.common.synchronized_timestamp import (
+    SynchronizedTimestamp,
+)
+from tsercom.timesync.server.server_synchronized_clock import (
+    ServerSynchronizedClock,
+)
+
+
+@pytest.fixture
+def server_clock() -> ServerSynchronizedClock:
+    """Fixture to create a ServerSynchronizedClock instance."""
+    return ServerSynchronizedClock()
+
+
+def test_desync(server_clock: ServerSynchronizedClock):
+    """
+    Tests that desync() returns the original datetime.datetime object
+    from a SynchronizedTimestamp.
+    """
+    original_dt = datetime.datetime(2023, 10, 26, 12, 0, 0)
+    st = SynchronizedTimestamp(original_dt)
+    desynced_dt = server_clock.desync(st)
+    assert desynced_dt is original_dt
+
+
+def test_sync(server_clock: ServerSynchronizedClock):
+    """
+    Tests that sync() wraps a datetime.datetime object in a
+    SynchronizedTimestamp.
+    """
+    original_dt = datetime.datetime(2023, 10, 26, 13, 0, 0)
+    synced_st = server_clock.sync(original_dt)
+
+    assert isinstance(synced_st, SynchronizedTimestamp)
+    assert synced_st.as_datetime() is original_dt
+
+
+def test_now_property(server_clock: ServerSynchronizedClock):
+    """
+    Tests the now property to ensure it returns a SynchronizedTimestamp
+    wrapping a recent, naive datetime, consistent with how ServerSynchronizedClock
+    should operate (similar to FakeSynchronizedClock as it doesn't apply offsets).
+    """
+    # Record time just before calling now
+    time_before = datetime.datetime.now()
+
+    current_st = server_clock.now
+    assert isinstance(current_st, SynchronizedTimestamp)
+
+    # Record time just after calling now
+    time_after = datetime.datetime.now()
+
+    dt_obj = current_st.as_datetime()
+
+    # Check that the datetime from the clock is between the times recorded
+    # just before and after the call. This allows for minor execution delays.
+    # A tolerance of 100ms should be more than enough.
+    assert dt_obj >= time_before - datetime.timedelta(microseconds=10000)
+    assert dt_obj <= time_after + datetime.timedelta(microseconds=10000)
+
+    # Check that the datetime object is naive (no timezone info)
+    assert dt_obj.tzinfo is None

--- a/tsercom/timesync/server/time_sync_server_unittest.py
+++ b/tsercom/timesync/server/time_sync_server_unittest.py
@@ -1,0 +1,691 @@
+"""Tests for TimeSyncServer."""
+
+import asyncio
+import errno
+import logging
+import socket
+import struct
+import time
+from unittest.mock import (
+    MagicMock,
+    patch,
+    call,
+)  # Import call for checking multiple calls
+
+import pytest
+from concurrent.futures import ThreadPoolExecutor
+
+from tsercom.timesync.common.packet_handler import NtpPacket
+from tsercom.timesync.common.constants import (
+    kNtpPort,
+    kNtpVersion,
+    kNtpServerMode,
+)
+from tsercom.timesync.server.server_synchronized_clock import (
+    ServerSynchronizedClock,
+)
+from tsercom.timesync.server.time_sync_server import TimeSyncServer
+from tsercom.util.is_running_tracker import IsRunningTracker
+
+
+# Default address and port for tests
+TEST_ADDRESS = "127.0.0.1"
+TEST_PORT = kNtpPort  # Or a different port if kNtpPort needs privileges
+
+
+@pytest.fixture
+def mock_socket_instance(mocker):
+    """Fixture to provide a mocked socket instance."""
+    mock_sock = MagicMock(spec=socket.socket)
+    mock_sock.fileno.return_value = 1  # Simulate an open socket
+    return mock_sock
+
+
+@pytest.fixture
+def mock_socket_module(mocker, mock_socket_instance):
+    """Fixture to mock the socket module, returning mock_socket_instance."""
+    mock_socket_class = mocker.patch("socket.socket")
+    mock_socket_class.return_value = mock_socket_instance
+    return mock_socket_class
+
+
+@pytest.fixture
+def mock_is_running_tracker(mocker):
+    """Fixture for a mocked IsRunningTracker."""
+    tracker = mocker.MagicMock(spec=IsRunningTracker)
+    tracker.get.return_value = False  # Default to not running
+
+    # When task_or_stopped is called, we need to control its behavior.
+    # For simplicity in many tests, let it return a future that resolves to None,
+    # or raise an exception if that's what's being tested.
+    # Specific tests will need to override this.
+    async def mock_task_or_stopped(task, timeout=None):
+        # This default behavior simulates the server stopping immediately
+        # or the task completing with None. Tests needing specific data
+        # from task_or_stopped (like __receive) will need to customize this.
+        if isinstance(task, asyncio.Future):
+            return await task  # If it's already a future
+        return None  # Default for loop termination
+
+    tracker.task_or_stopped = MagicMock(side_effect=mock_task_or_stopped)
+    return tracker
+
+
+@pytest.fixture
+def mock_run_on_event_loop(mocker):
+    """Mocks aio_utils.run_on_event_loop."""
+    # This mock needs to handle being called with a coroutine.
+    # For basic tests, we can just store the coroutine.
+    # For more advanced tests, we might need it to execute the coroutine.
+    # By default, let's make it a simple mock that doesn't execute.
+    return mocker.patch("tsercom.threading.aio.aio_utils.run_on_event_loop")
+
+
+@pytest.fixture
+def mock_get_running_loop_or_none(mocker):
+    """Mocks aio_utils.get_running_loop_or_none."""
+    # Return a MagicMock for an event loop by default.
+    # Specific tests can customize its behavior.
+    mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    mock_loop.time.return_value = time.time()  # For NtpPacket timestamps
+    return mocker.patch(
+        "tsercom.threading.aio.aio_utils.get_running_loop_or_none",
+        return_value=mock_loop,
+    )
+
+
+@pytest.fixture
+def mock_thread_pool_executor(mocker):
+    """Mocks ThreadPoolExecutor."""
+    # This fixture provides a mock for ThreadPoolExecutor.
+    # We'll mock the class itself.
+    mock_executor_class = mocker.patch("concurrent.futures.ThreadPoolExecutor")
+    # And the instance it returns, specifically its methods like submit, shutdown.
+    mock_executor_instance = MagicMock(spec=ThreadPoolExecutor)
+    mock_executor_class.return_value = mock_executor_instance
+    return mock_executor_instance
+
+
+@pytest.fixture
+def server(
+    mock_socket_module,
+    mock_is_running_tracker,
+    mock_run_on_event_loop,
+    mock_get_running_loop_or_none,
+    mock_thread_pool_executor,
+):
+    """Fixture to create a TimeSyncServer instance with mocked dependencies."""
+    # Temporarily unpatch IsRunningTracker for the server's own instance
+    with patch(
+        "tsercom.timesync.server.time_sync_server.IsRunningTracker",
+        return_value=mock_is_running_tracker,
+    ):
+        server_instance = TimeSyncServer(
+            address=TEST_ADDRESS, ntp_port=TEST_PORT
+        )
+        # Replace the automatically created socket with our controlled mock_socket_instance
+        server_instance._TimeSyncServer__socket = (
+            mock_socket_module.return_value
+        )
+    return server_instance
+
+
+# --- Test Cases ---
+
+
+def test_init(
+    server: TimeSyncServer, mock_socket_module, mock_is_running_tracker
+):
+    """Tests basic initialization of TimeSyncServer."""
+    assert server._TimeSyncServer__address == TEST_ADDRESS
+    assert server._TimeSyncServer__port == TEST_PORT
+
+    # Check that the server's __is_running tracker is the one we injected or a similar mock
+    # This depends on how the server fixture is set up. If server fixture uses the mock_is_running_tracker directly:
+    assert server._TimeSyncServer__is_running is mock_is_running_tracker
+    # Or, if TimeSyncServer creates its own IsRunningTracker, verify it was called:
+    # mock_is_running_tracker_class.assert_called_once() (this needs a different mock setup)
+
+    # Verify initial state of the tracker if it's our mock
+    mock_is_running_tracker.get.assert_called()  # is_running() calls this
+    assert not server.is_running()
+
+    mock_socket_module.assert_called_once_with(
+        socket.AF_INET, socket.SOCK_DGRAM
+    )
+    assert server._TimeSyncServer__socket is mock_socket_module.return_value
+    assert (
+        server._TimeSyncServer__executor is not None
+    )  # Executor should be initialized
+
+
+def test_get_synchronized_clock(server: TimeSyncServer):
+    """Tests that get_synchronized_clock returns a ServerSynchronizedClock instance."""
+    clock = server.get_synchronized_clock()
+    assert isinstance(clock, ServerSynchronizedClock)
+
+
+# More tests will be added here.
+# For now, this sets up the basic structure and some initial tests.
+# The __run_server, __receive, __send tests will be more complex and likely async.
+# Need to consider how ThreadPoolExecutor is used by __receive and __send if testing them through __run_server.
+# The mock_executor from mock_thread_pool_executor will be associated with server._TimeSyncServer__executor.
+# loop.run_in_executor will use this executor.
+# We'll need to mock the return value of executor.submit(socket_method, *args) for __receive/__send.
+
+
+# Placeholder for __bind_socket tests
+class TestBindSocket:
+    def test_bind_socket_success(
+        self,
+        server: TimeSyncServer,
+        mock_socket_instance,
+        mock_is_running_tracker,
+    ):
+        """Tests successful socket binding."""
+        server._TimeSyncServer__bind_socket()
+        mock_socket_instance.bind.assert_called_once_with(
+            (TEST_ADDRESS, TEST_PORT)
+        )
+        mock_is_running_tracker.set.assert_called_once_with(True)
+
+    def test_bind_socket_eaddrinuse(
+        self,
+        server: TimeSyncServer,
+        mock_socket_instance,
+        mock_is_running_tracker,
+        mocker,
+    ):
+        """Tests socket binding when address is already in use."""
+        mock_logging_error = mocker.patch("logging.error")
+        mock_socket_instance.bind.side_effect = OSError(
+            errno.EADDRINUSE, "Address already in use"
+        )
+
+        server._TimeSyncServer__bind_socket()
+
+        mock_socket_instance.bind.assert_called_once_with(
+            (TEST_ADDRESS, TEST_PORT)
+        )
+        mock_logging_error.assert_called_once()
+        assert "Address already in use" in mock_logging_error.call_args[0][0]
+        # Check that set(False) was called. If set(True) was called before the error,
+        # there would be two calls. If only set(False) is guaranteed, then one specific call.
+        # Assuming it might try to set True then corrects to False, or just sets False.
+        # For this test, we primarily care that it ends up False.
+        # The IsRunningTracker mock needs to be sophisticated to track call order if needed.
+        # Let's assume the final call to set should be False.
+        mock_is_running_tracker.set.assert_called_with(
+            False
+        )  # Check the last call or any call
+
+    def test_bind_socket_other_oserror(
+        self,
+        server: TimeSyncServer,
+        mock_socket_instance,
+        mock_is_running_tracker,
+    ):
+        """Tests socket binding with another OSError."""
+        expected_error = OSError(errno.ECONNRESET, "Other error")
+        mock_socket_instance.bind.side_effect = expected_error
+
+        with pytest.raises(OSError) as excinfo:
+            server._TimeSyncServer__bind_socket()
+
+        assert excinfo.value is expected_error
+        mock_socket_instance.bind.assert_called_once_with(
+            (TEST_ADDRESS, TEST_PORT)
+        )
+        mock_is_running_tracker.set.assert_called_with(False)
+
+
+# Placeholder for start_async tests
+class TestStartAsync:
+    def test_start_async_success(
+        self,
+        server: TimeSyncServer,
+        mock_is_running_tracker,
+        mock_run_on_event_loop,
+        mocker,
+    ):
+        """Tests successful start_async."""
+        # Mock __bind_socket to simulate it working
+        mocker.patch.object(
+            server, "_TimeSyncServer__bind_socket", return_value=None
+        )
+        # Simulate that __bind_socket would set is_running to True
+        mock_is_running_tracker.get.return_value = (
+            False  # Initially not running
+        )
+
+        def bind_effect():
+            mock_is_running_tracker.get.return_value = (
+                True  # After bind, it's running
+            )
+
+        server._TimeSyncServer__bind_socket.side_effect = bind_effect
+
+        server.start_async()
+
+        server._TimeSyncServer__bind_socket.assert_called_once()
+        mock_run_on_event_loop.assert_called_once_with(
+            server._TimeSyncServer__run_server
+        )  # pyright: ignore[reportPrivateUsage]
+        # is_running should be true now because bind_socket (mocked) was successful
+        # and run_on_event_loop was called.
+        # The mock_is_running_tracker.get.return_value was changed by the side_effect.
+        assert server.is_running()
+
+    def test_start_async_already_running(
+        self, server: TimeSyncServer, mock_is_running_tracker, mocker
+    ):
+        """Tests calling start_async when the server is already running."""
+        # Simulate server is already running
+        mock_is_running_tracker.get.return_value = True
+        # Mock __bind_socket as it shouldn't be called if already running
+        mock_bind = mocker.patch.object(server, "_TimeSyncServer__bind_socket")
+
+        with pytest.raises(
+            AssertionError,
+            match="TimeSyncServer is already running or has not been fully stopped.",
+        ):
+            server.start_async()
+
+        mock_bind.assert_not_called()
+
+
+# Placeholder for stop tests
+class TestStop:
+    def test_stop_server(
+        self,
+        server: TimeSyncServer,
+        mock_socket_instance,
+        mock_is_running_tracker,
+        mock_socket_module,
+        mocker,
+    ):
+        """Tests stopping the server."""
+        # Simulate server is running
+        mock_is_running_tracker.get.return_value = True
+        server._TimeSyncServer__is_running = (
+            mock_is_running_tracker  # Ensure server uses the mock
+        )
+
+        # Mock the temporary socket used for shutdown
+        mock_temp_sock_instance = MagicMock(spec=socket.socket)
+        # When socket.socket is called from server.stop(), it should return this temp mock
+        # This requires mock_socket_module (which is a mock of the class 'socket.socket')
+        # to return different instances based on context, or we re-patch it locally.
+
+        # For simplicity, let's assume the main server socket is mock_socket_instance
+        # and any new socket created in stop() will also use the mock_socket_module factory.
+        # We need to ensure the factory produces our mock_temp_sock_instance for the stop call.
+        mocker.patch("socket.socket", return_value=mock_temp_sock_instance)
+
+        server.stop()
+
+        # is_running should be set to False
+        mock_is_running_tracker.set.assert_called_with(False)
+
+        # The main server socket should be closed
+        mock_socket_instance.close.assert_called_once()
+
+        # A temporary socket should have been created and used to send data to unblock the main loop
+        # This relies on socket.socket being re-mocked effectively for the stop() method's scope
+        mock_temp_sock_instance.sendto.assert_called_once()
+        # The first argument to sendto is usually bytes(0) or similar
+        # The second argument is the server's own address
+        args, _ = mock_temp_sock_instance.sendto.call_args
+        assert isinstance(args[0], bytes)
+        assert args[1] == (TEST_ADDRESS, TEST_PORT)
+        mock_temp_sock_instance.close.assert_called_once()
+
+
+# Placeholder for __run_server tests (very basic example)
+@pytest.mark.asyncio
+async def test_run_server_stops_if_not_running(
+    server: TimeSyncServer,
+    mock_is_running_tracker,
+    mock_get_running_loop_or_none,
+):
+    """Tests that __run_server terminates if is_running starts as False."""
+    mock_is_running_tracker.get.return_value = (
+        False  # Server should not be running
+    )
+
+    # Ensure get_running_loop_or_none returns a loop that can be used by task_or_stopped
+    # The fixture mock_get_running_loop_or_none already provides a mock loop.
+    # The mock_is_running_tracker.task_or_stopped might need to use this loop.
+
+    await server._TimeSyncServer__run_server()  # pyright: ignore[reportPrivateUsage]
+
+    # Assert that no receive/send operations happened, etc.
+    # For this simple test, just ensuring it doesn't hang is key.
+    # mock_is_running_tracker.task_or_stopped should not have been called if it exits early.
+    # However, the loop structure is `while self.__is_running.get():`, so task_or_stopped is inside.
+    # If get() is false initially, the loop doesn't run, so task_or_stopped isn't called.
+    mock_is_running_tracker.task_or_stopped.assert_not_called()
+
+
+# More detailed __run_server tests will require careful mocking of
+# __receive, __send, NtpPacket, and the event loop interactions.
+# Example of a more involved __run_server test:
+@pytest.mark.asyncio
+async def test_run_server_processes_one_packet(
+    server: TimeSyncServer,
+    mock_is_running_tracker,
+    mock_socket_instance,
+    mock_get_running_loop_or_none,
+    mock_thread_pool_executor,
+    mocker,
+):
+    """Tests __run_server processing a single valid NTP packet."""
+    # Setup is_running to run the loop once then stop
+    mock_is_running_tracker.get.side_effect = [True, False]  # Run loop once
+
+    # Mock the event loop returned by get_running_loop_or_none
+    mock_loop = mock_get_running_loop_or_none.return_value
+
+    # Client address
+    client_addr = ("client_ip", 12345)
+
+    # Create a valid client NTP packet (raw bytes)
+    # This is simplified; a real packet would have more fields set.
+    client_packet = NtpPacket(
+        version=kNtpVersion, mode=3, tx_timestamp=time.time()
+    )  # Client mode = 3
+    raw_client_packet = client_packet.pack()
+
+    # Mock what __receive (via task_or_stopped) should return
+    # __receive itself uses run_in_executor. So we need to mock the result of that.
+    # The task passed to task_or_stopped will be loop.run_in_executor(...)
+    # We need task_or_stopped to simulate this task completing.
+
+    # 1. Mock loop.run_in_executor
+    #    The first call to run_in_executor is from __receive()
+    #    The second call to run_in_executor is from __send()
+    async def mock_run_in_executor_effect(executor, func, *args):
+        if func == mock_socket_instance.recvfrom:  # This is from __receive
+            return (raw_client_packet, client_addr)
+        elif func == mock_socket_instance.sendto:  # This is from __send
+            return len(
+                raw_client_packet
+            )  # sendto returns number of bytes sent
+        return None
+
+    mock_loop.run_in_executor = MagicMock(
+        side_effect=mock_run_in_executor_effect
+    )
+
+    # Now, configure task_or_stopped to correctly await the future from run_in_executor
+    # The default side_effect of task_or_stopped is `await task` if task is a future.
+    # Here, run_on_event_loop calls __run_server. Inside __run_server,
+    # self.__receive is called, which calls task_or_stopped(self.__loop.run_in_executor(...))
+    # So we need to ensure that the mock_loop.run_in_executor is what task_or_stopped receives.
+
+    # We need to make sure that task_or_stopped receives the *result* of run_in_executor,
+    # not the coroutine itself, because task_or_stopped is for managing the executor call.
+    # The structure is:
+    #   task_or_stopped( self.__loop.run_in_executor(self.__executor, self.__socket.recvfrom, kMaxPacketSize) )
+    # Let's re-evaluate the mock for task_or_stopped for this specific test.
+
+    # task_or_stopped is called with the *future* returned by run_in_executor.
+    # It should await this future.
+    # The run_in_executor mock should return the data directly if it's not returning a future.
+    # If run_in_executor is a standard asyncio method, it returns a future.
+    # Our mock_run_in_executor_effect returns data directly, so it behaves like an awaited future.
+    # So, the default task_or_stopped which does `return await task` should work if `task` is
+    # the result of our `mock_run_in_executor_effect`.
+    # This needs `task_or_stopped` to effectively pass through the result of its `task` argument.
+
+    # Let's simplify: task_or_stopped needs to return what run_in_executor would return after being awaited.
+    # The first call to task_or_stopped is for __receive.
+    # The second call to task_or_stopped is for __send.
+    task_or_stopped_results = [
+        (raw_client_packet, client_addr),  # Result for __receive
+        len(raw_client_packet),  # Result for __send
+    ]
+    mock_is_running_tracker.task_or_stopped.side_effect = (
+        task_or_stopped_results
+    )
+
+    await server._TimeSyncServer__run_server()  # pyright: ignore[reportPrivateUsage]
+
+    # Verify __receive was effectively called (via run_in_executor)
+    # Verify __send was effectively called (via run_in_executor)
+    assert mock_loop.run_in_executor.call_count == 2
+
+    # Check call for recvfrom
+    args_recv, _ = mock_loop.run_in_executor.call_args_list[0]
+    assert args_recv[1] == mock_socket_instance.recvfrom
+    assert args_recv[2] == 4096  # kMaxPacketSize
+
+    # Check call for sendto
+    args_send, _ = mock_loop.run_in_executor.call_args_list[1]
+    assert args_send[1] == mock_socket_instance.sendto
+    # args_send[2] is the packed response data, args_send[3] is client_addr
+    # We need to validate the content of args_send[2] (the response packet)
+    response_data_sent = args_send[2]
+    assert isinstance(response_data_sent, bytes)
+    response_packet = NtpPacket.unpack(response_data_sent)
+
+    assert response_packet.version == kNtpVersion
+    assert response_packet.mode == kNtpServerMode  # Server mode = 4
+    assert response_packet.stratum == 2  # Default server stratum
+    # Timestamps should be populated
+    assert response_packet.recv_timestamp != 0
+    assert response_packet.tx_timestamp != 0
+    assert (
+        response_packet.orig_timestamp == client_packet.tx_timestamp
+    )  # Should echo client's tx_timestamp
+
+    # Ensure is_running.get() was called twice
+    assert mock_is_running_tracker.get.call_count == 2
+    # Ensure task_or_stopped was called twice
+    assert mock_is_running_tracker.task_or_stopped.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_server_malformed_packet(
+    server: TimeSyncServer,
+    mock_is_running_tracker,
+    mock_socket_instance,
+    mock_get_running_loop_or_none,
+    mocker,
+):
+    """Tests __run_server handling a malformed NTP packet."""
+    mock_is_running_tracker.get.side_effect = [True, False]  # Run loop once
+    mock_logging_warning = mocker.patch("logging.warning")
+    mock_loop = mock_get_running_loop_or_none.return_value
+
+    malformed_packet_data = b"\x17\x00\x03\xfa"  # Too short to be valid
+    client_addr = ("client_ip", 12345)
+
+    # Simulate __receive returning malformed data
+    async def mock_run_in_executor_recv(*args, **kwargs):
+        return (malformed_packet_data, client_addr)
+
+    mock_loop.run_in_executor.side_effect = mock_run_in_executor_recv
+
+    # task_or_stopped should return the result of the (mocked) run_in_executor
+    mock_is_running_tracker.task_or_stopped.side_effect = [
+        (malformed_packet_data, client_addr)
+    ]
+
+    await server._TimeSyncServer__run_server()  # pyright: ignore[reportPrivateUsage]
+
+    mock_logging_warning.assert_called_once()
+    assert (
+        "Malformed NTP packet received" in mock_logging_warning.call_args[0][0]
+    )
+    # Ensure sendto was not called
+    send_calls = [
+        c
+        for c in mock_loop.run_in_executor.call_args_list
+        if c[0][1] == mock_socket_instance.sendto
+    ]
+    assert len(send_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_server_invalid_ntp_version_or_mode(
+    server: TimeSyncServer,
+    mock_is_running_tracker,
+    mock_socket_instance,
+    mock_get_running_loop_or_none,
+    mocker,
+):
+    """Tests __run_server handling NTP packet with invalid version/mode."""
+    mock_is_running_tracker.get.side_effect = [True, False]
+    mock_logging_warning = mocker.patch("logging.warning")
+    mock_loop = mock_get_running_loop_or_none.return_value
+
+    # Packet with bad version
+    invalid_packet_v_obj = NtpPacket(
+        version=7, mode=3, tx_timestamp=time.time()
+    )  # version 7 is invalid
+    invalid_packet_v_raw = invalid_packet_v_obj.pack()
+    client_addr = ("client_ip", 12345)
+
+    # Simulate __receive returning this packet
+    async def mock_run_in_executor_recv_invalid(*args, **kwargs):
+        return (invalid_packet_v_raw, client_addr)
+
+    mock_loop.run_in_executor.side_effect = mock_run_in_executor_recv_invalid
+    mock_is_running_tracker.task_or_stopped.side_effect = [
+        (invalid_packet_v_raw, client_addr)
+    ]
+
+    await server._TimeSyncServer__run_server()  # pyright: ignore[reportPrivateUsage]
+
+    mock_logging_warning.assert_called_once()
+    assert (
+        "Invalid NTP version or mode" in mock_logging_warning.call_args[0][0]
+    )
+    # Ensure sendto was not called
+    send_calls = [
+        c
+        for c in mock_loop.run_in_executor.call_args_list
+        if c[0][1] == mock_socket_instance.sendto
+    ]
+    assert len(send_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_server_socket_closed_fileno_minus_one(
+    server: TimeSyncServer,
+    mock_is_running_tracker,
+    mock_socket_instance,
+    mock_get_running_loop_or_none,
+):
+    """Tests __run_server termination if socket.fileno() is -1 (closed)."""
+    mock_is_running_tracker.get.return_value = True  # Try to run loop
+    mock_socket_instance.fileno.return_value = -1  # Socket is closed
+
+    # No need to mock task_or_stopped as it shouldn't be reached if fileno check is first
+    await server._TimeSyncServer__run_server()  # pyright: ignore[reportPrivateUsage]
+
+    mock_is_running_tracker.get.assert_called_once()  # Checked once
+    mock_socket_instance.fileno.assert_called_once()
+    # task_or_stopped for __receive should not be called
+    # This depends on the implementation detail of where fileno() is checked.
+    # Based on typical server loops, it's checked before recvfrom.
+    receive_calls = [
+        c for c in mock_is_running_tracker.task_or_stopped.call_args_list
+    ]  # Check all calls to task_or_stopped
+    assert len(receive_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_receive_wraps_run_in_executor(
+    server: TimeSyncServer, mock_socket_instance, mock_get_running_loop_or_none
+):
+    """Tests that __receive correctly uses loop.run_in_executor."""
+    mock_loop = mock_get_running_loop_or_none.return_value
+    expected_data = (b"dummy_data", ("dummy_addr", 123))
+
+    # run_in_executor should return a future. Let's mock it to return an already resolved future.
+    # Or, for simplicity in testing the call, let it return the data directly.
+    async def mock_executor_call(*args):
+        return expected_data
+
+    mock_loop.run_in_executor = MagicMock(side_effect=mock_executor_call)
+
+    server._TimeSyncServer__loop = mock_loop  # Ensure server uses this loop
+
+    result = await server._TimeSyncServer__receive(
+        mock_socket_instance
+    )  # pyright: ignore[reportPrivateUsage]
+
+    assert result == expected_data
+    mock_loop.run_in_executor.assert_called_once_with(
+        server._TimeSyncServer__executor,  # pyright: ignore[reportPrivateUsage]
+        mock_socket_instance.recvfrom,
+        4096,  # kMaxPacketSize
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_wraps_run_in_executor(
+    server: TimeSyncServer, mock_socket_instance, mock_get_running_loop_or_none
+):
+    """Tests that __send correctly uses loop.run_in_executor."""
+    mock_loop = mock_get_running_loop_or_none.return_value
+    test_data = b"test_payload"
+    test_addr = ("test_client", 54321)
+    expected_bytes_sent = len(test_data)
+
+    async def mock_executor_call_send(*args):
+        return expected_bytes_sent
+
+    mock_loop.run_in_executor = MagicMock(side_effect=mock_executor_call_send)
+
+    server._TimeSyncServer__loop = mock_loop  # Ensure server uses this loop
+
+    await server._TimeSyncServer__send(
+        mock_socket_instance, test_data, test_addr
+    )  # pyright: ignore[reportPrivateUsage]
+
+    mock_loop.run_in_executor.assert_called_once_with(
+        server._TimeSyncServer__executor,  # pyright: ignore[reportPrivateUsage]
+        mock_socket_instance.sendto,
+        test_data,
+        test_addr,
+    )
+
+
+# Final check for copyright header removal
+# The file is created without it, so this is mostly a reminder.
+# Ensure no part of the generation process adds it.
+# (This would be handled by the overall system, not code in this block)
+
+# Test that run_on_event_loop is correctly used by start_async
+# This is partially covered in TestStartAsync.test_start_async_success
+# but can be made more explicit if needed.
+# server.start_async() -> run_on_event_loop(server.__run_server)
+
+# Test ThreadPoolExecutor usage
+# The mock_thread_pool_executor fixture creates a mock for the executor instance.
+# The __receive and __send tests implicitly test that this executor is passed to run_in_executor.
+# We can add assertions to check if executor.submit was called if run_in_executor was not fully mocked.
+# However, loop.run_in_executor is the direct asyncio API.
+# If ThreadPoolExecutor is managed internally by TimeSyncServer and passed to run_in_executor,
+# then mock_loop.run_in_executor.assert_called_once_with(server._TimeSyncServer__executor, ...) is correct.
+
+# Mocking logging:
+# Individual tests like test_bind_socket_eaddrinuse and __run_server malformed packet tests
+# already use mocker.patch("logging.error") or mocker.patch("logging.warning").
+# This is the standard way to test logging calls.
+# A global logging mock isn't usually necessary unless testing overall logging behavior.
+
+# IsRunningTracker.task_or_stopped:
+# This is critical for __run_server. The mock_is_running_tracker fixture
+# provides a basic version. More complex tests (like test_run_server_processes_one_packet)
+# customize its side_effect to return specific data or simulate sequences of events.
+# This seems like a reasonable approach.
+# Key is that task_or_stopped must be awaitable if the task it's given is awaitable,
+# or return the result directly if the underlying call is blocking but wrapped by run_in_executor.
+# The current mock for task_or_stopped (await task if task is future, else None)
+# might need refinement if 'task' is not a future but a coroutine function itself.
+# However, loop.run_in_executor returns a Future, so `await task` is correct.
+# And for __run_server, task_or_stopped is called with the future from run_in_executor.

--- a/tsercom/util/is_running_tracker_unittest.py
+++ b/tsercom/util/is_running_tracker_unittest.py
@@ -1,0 +1,319 @@
+"""Tests for IsRunningTracker."""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from tsercom.util.is_running_tracker import IsRunningTracker
+from tsercom.threading.aio import aio_utils
+
+
+@pytest.fixture
+def tracker() -> IsRunningTracker:
+    """Fixture to create an IsRunningTracker instance."""
+    return IsRunningTracker()
+
+
+def test_initialization(tracker: IsRunningTracker):
+    """Tests that IsRunningTracker initializes with is_running as False."""
+    assert not tracker.is_running
+
+
+def test_start(tracker: IsRunningTracker):
+    """Tests that start() sets is_running to True."""
+    tracker.start()
+    assert tracker.is_running
+
+
+def test_stop(tracker: IsRunningTracker):
+    """Tests that stop() sets is_running to False."""
+    tracker.start()  # Start first
+    tracker.stop()
+    assert not tracker.is_running
+
+
+def test_set_true(tracker: IsRunningTracker):
+    """Tests that set(True) sets is_running to True."""
+    tracker.set(True)
+    assert tracker.is_running
+
+
+def test_set_false(tracker: IsRunningTracker):
+    """Tests that set(False) sets is_running to False."""
+    tracker.set(True)  # Start first
+    tracker.set(False)
+    assert not tracker.is_running
+
+
+def test_basic_sequence(tracker: IsRunningTracker):
+    """Tests a basic sequence of operations."""
+    assert not tracker.is_running  # Initial state
+    tracker.start()
+    assert tracker.is_running
+    tracker.stop()
+    assert not tracker.is_running
+    tracker.set(True)
+    assert tracker.is_running
+    tracker.set(False)
+    assert not tracker.is_running
+
+
+@pytest.fixture
+async def running_tracker(event_loop: asyncio.AbstractEventLoop):
+    """
+    Fixture to create an IsRunningTracker instance associated with the
+    current event_loop.
+    """
+    tracker = IsRunningTracker()
+    # Associate the tracker with the current event loop
+    tracker._IsRunningTracker__event_loop = (
+        event_loop  # pyright: ignore[reportPrivateUsage]
+    )
+
+
+from functools import partial
+from unittest.mock import MagicMock
+
+
+def run_async(coro):
+    """Helper to run a coroutine if a test function cannot be async."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+def test_methods_fail_without_proper_event_loop_setup(mocker):
+    """
+    Tests that async utility methods fail as expected if the event loop
+    is not properly initialized within IsRunningTracker.
+    """
+    # Mock get_running_loop_or_none where it's imported by IsRunningTracker
+    mock_get_loop = mocker.patch(
+        "tsercom.util.is_running_tracker.get_running_loop_or_none",
+        return_value=None,
+    )
+    # This mock is for aio_utils.run_on_event_loop's internal call
+    mock_aio_get_loop = mocker.patch(
+        "tsercom.threading.aio.aio_utils.get_running_loop_or_none",
+        return_value=None,
+    )
+
+    err_msg_ensure_loop = "Must be called from within a running event loop or have an event loop set."
+    err_msg_run_on_event_loop = (
+        "No event loop is running, and no event loop was previously set."
+    )
+
+    # Sub-test for __ensure_event_loop_initialized direct call
+    tracker = IsRunningTracker()
+    with pytest.raises(AssertionError, match=err_msg_ensure_loop):
+        run_async(
+            tracker._IsRunningTracker__ensure_event_loop_initialized()
+        )  # pyright: ignore[reportPrivateUsage]
+    mock_get_loop.assert_called_once()
+    assert (
+        tracker._IsRunningTracker__event_loop is None
+    )  # pyright: ignore[reportPrivateUsage]
+    mock_get_loop.reset_mock()
+
+    # Sub-test for wait_until_started() when tracker is stopped (initial state)
+    tracker = IsRunningTracker()  # New instance, initially False (stopped)
+    # It will call __ensure_event_loop_initialized because it's not running
+    with pytest.raises(AssertionError, match=err_msg_ensure_loop):
+        run_async(tracker.wait_until_started())
+    if not tracker.get():  # Should be true
+        mock_get_loop.assert_called_once()
+    assert (
+        tracker._IsRunningTracker__event_loop is None
+    )  # pyright: ignore[reportPrivateUsage]
+    mock_get_loop.reset_mock()
+
+    # Sub-test for wait_until_stopped() when tracker is running
+    # This requires the tracker to be "running" and its __event_loop to be None initially
+    # for __ensure_event_loop_initialized to be called by wait_until_stopped.
+    tracker_ws_running = IsRunningTracker()
+    # Manually set tracker to running state without involving proper event loop init for set()
+    tracker_ws_running._Atomic__value = (
+        True  # pylint: disable=protected-access
+    )
+    assert tracker_ws_running.is_running
+    assert (
+        tracker_ws_running._IsRunningTracker__event_loop is None
+    )  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(AssertionError, match=err_msg_ensure_loop):
+        run_async(tracker_ws_running.wait_until_stopped())
+    # __ensure_event_loop_initialized is called by wait_until_stopped when self.get() is True
+    mock_get_loop.assert_called_once()
+    assert (
+        tracker_ws_running._IsRunningTracker__event_loop is None
+    )  # pyright: ignore[reportPrivateUsage]
+    mock_get_loop.reset_mock()
+
+    # Sub-test for wait_until_stopped() when tracker is already stopped (initial state)
+    tracker_ws_stopped = (
+        IsRunningTracker()
+    )  # New instance, initially False (stopped)
+    # It returns early, __ensure_event_loop_initialized is not called.
+    run_async(tracker_ws_stopped.wait_until_stopped())
+    mock_get_loop.assert_not_called()  # Not called because it returns early
+    assert (
+        tracker_ws_stopped._IsRunningTracker__event_loop is None
+    )  # pyright: ignore[reportPrivateUsage]
+
+    # --- Sub-tests for set(), start(), stop() that use run_on_event_loop ---
+    # These expect run_on_event_loop to fail because its internal call to
+    # aio_utils.get_running_loop_or_none (mocked by mock_aio_get_loop) returns None.
+
+    tracker_set = IsRunningTracker()
+    with pytest.raises(AssertionError, match=err_msg_run_on_event_loop):
+        # tracker.set() is sync, but the coroutine it schedules via run_on_event_loop will fail.
+        # We need to execute that coroutine.
+        # The actual IsRunningTracker.set() is synchronous and won't raise here directly.
+        # The error comes from task.result() if not on loop, or from the loop itself.
+        # For this test, we assume we are "not on the loop" when calling set,
+        # so task.result() would be called.
+        # To simulate this, we'd need to mock run_on_event_loop more deeply or
+        # test the behavior of the scheduled partial(self.__set_impl, value)
+        # when run_on_event_loop itself can't find a loop.
+        # The simplest is to check if set() fails if run_on_event_loop fails.
+        mocker.patch(
+            "tsercom.util.is_running_tracker.is_running_on_event_loop",
+            return_value=False,
+        )
+        tracker_set.set(
+            True
+        )  # This should call task.result() internally and raise
+    mock_aio_get_loop.assert_called_once()  # run_on_event_loop calls get_running_loop_or_none
+    mock_aio_get_loop.reset_mock()
+
+    tracker_start = IsRunningTracker()
+    with pytest.raises(AssertionError, match=err_msg_run_on_event_loop):
+        mocker.patch(
+            "tsercom.util.is_running_tracker.is_running_on_event_loop",
+            return_value=False,
+        )
+        tracker_start.start()
+    mock_aio_get_loop.assert_called_once()
+    mock_aio_get_loop.reset_mock()
+
+    tracker_stop = IsRunningTracker()
+    # Manually set to running so stop actually tries to do async work
+    tracker_stop._Atomic__value = True  # pylint: disable=protected-access
+    tracker_stop._IsRunningTracker__event_loop = MagicMock(
+        spec=asyncio.AbstractEventLoop
+    )  # pyright: ignore[reportPrivateUsage]
+    # Temporarily allow aio_utils.get_running_loop_or_none to return this mock loop
+    # so that the initial part of set() in stop() can find a loop.
+    mock_aio_get_loop.return_value = (
+        tracker_stop._IsRunningTracker__event_loop
+    )  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(AssertionError, match=err_msg_run_on_event_loop):
+        mocker.patch(
+            "tsercom.util.is_running_tracker.is_running_on_event_loop",
+            return_value=False,
+        )
+        # Now, when stop() calls set(False), make sure aio_utils.get_running_loop_or_none returns None again
+        # This is tricky because the loop is captured by `run_on_event_loop` at the time of the call.
+        # The current mock setup for mock_aio_get_loop will make run_on_event_loop (inside set)
+        # get None when it calls get_running_loop_or_none.
+
+        # The most direct way to test stop() failing if the loop disappears:
+        # 1. Tracker is running, has an associated loop.
+        # 2. Mock aio_utils.get_running_loop_or_none to NOW return None.
+        # 3. Call stop(). The run_on_event_loop inside set() should pick up the None.
+        mock_aio_get_loop.return_value = (
+            None  # Critical change for this specific call path
+        )
+        tracker_stop.stop()  # which calls set(False)
+    # It should be called when run_on_event_loop (called by set) tries to get a loop.
+    mock_aio_get_loop.assert_called()  # Assert it was called (at least once, due to prior return_value change)
+
+
+def test_set_method_interaction_with_run_on_event_loop_and_clear(mocker):
+    """
+    Tests the set() method's interaction with run_on_event_loop
+    and the clear() callback.
+    """
+    mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+    # Mock where run_on_event_loop is imported and used by IsRunningTracker.set
+    mock_run_on_event_loop = mocker.patch(
+        "tsercom.util.is_running_tracker.run_on_event_loop"
+    )
+    mock_task = MagicMock(spec=asyncio.Task)
+    mock_run_on_event_loop.return_value = mock_task
+
+    # Mock is_running_on_event_loop to simulate not being on the loop,
+    # so task.result() gets called.
+    mock_is_running_on_event_loop = mocker.patch(
+        "tsercom.util.is_running_tracker.is_running_on_event_loop",
+        return_value=False,
+    )
+
+    tracker = IsRunningTracker()
+    # Manually set the event loop for this test, as __ensure_event_loop_initialized
+    # would normally do this. This is white-box testing.
+    tracker._IsRunningTracker__event_loop = (
+        mock_loop  # pyright: ignore[reportPrivateUsage]
+    )
+
+    # Call set()
+    tracker.set(True)
+
+    # Assert run_on_event_loop was called correctly
+    assert mock_run_on_event_loop.call_count == 1
+    call_args = mock_run_on_event_loop.call_args[0]
+    assert isinstance(call_args[0], partial)
+    assert (
+        call_args[0].func == tracker._IsRunningTracker__set_impl
+    )  # pyright: ignore[reportPrivateUsage]
+    assert call_args[0].args == (True,)
+    assert call_args[1] is mock_loop
+
+    # Assert add_done_callback was called on the mock task
+    mock_task.add_done_callback.assert_called_once()
+    clear_callback = mock_task.add_done_callback.call_args[0][0]
+
+    # Keep original event objects for comparison
+    original_running_barrier = (
+        tracker._IsRunningTracker__running_barrier
+    )  # pyright: ignore[reportPrivateUsage]
+    original_stopped_barrier = (
+        tracker._IsRunningTracker__stopped_barrier
+    )  # pyright: ignore[reportPrivateUsage]
+
+    # Invoke the clear callback
+    clear_callback(None)  # Argument is the future, not used by clear
+
+    # Check that barriers are new event objects
+    assert (
+        tracker._IsRunningTracker__running_barrier
+        is not original_running_barrier
+    )  # pyright: ignore[reportPrivateUsage]
+    assert (
+        tracker._IsRunningTracker__stopped_barrier
+        is not original_stopped_barrier
+    )  # pyright: ignore[reportPrivateUsage]
+    # Check their state (should be default: not set)
+    assert (
+        not tracker._IsRunningTracker__running_barrier.is_set()
+    )  # pyright: ignore[reportPrivateUsage]
+    assert (
+        not tracker._IsRunningTracker__stopped_barrier.is_set()
+    )  # pyright: ignore[reportPrivateUsage]
+
+    # Check that __event_loop is set to None
+    assert (
+        tracker._IsRunningTracker__event_loop is None
+    )  # pyright: ignore[reportPrivateUsage]
+
+    # Ensure task.result() was called
+    mock_task.result.assert_called_once()
+    mock_is_running_on_event_loop.assert_called_once_with(mock_loop)

--- a/tsercom/util/stopable_unittest.py
+++ b/tsercom/util/stopable_unittest.py
@@ -1,0 +1,31 @@
+"""Tests for Stopable."""
+
+import pytest
+
+from tsercom.util.stopable import Stopable
+
+
+class GoodStopable(Stopable):
+    """A concrete implementation of Stopable that correctly implements stop."""
+
+    async def stop(self) -> None:
+        """Stops the Stopable."""
+        pass
+
+
+class BadStopable(Stopable):
+    """A concrete implementation of Stopable that does not implement stop."""
+
+    pass
+
+
+def test_good_stopable_instantiation():
+    """Tests that GoodStopable can be instantiated."""
+    good_stopable = GoodStopable()
+    assert isinstance(good_stopable, Stopable)
+
+
+def test_bad_stopable_instantiation():
+    """Tests that BadStopable cannot be instantiated due to missing stop method."""
+    with pytest.raises(TypeError):
+        BadStopable()


### PR DESCRIPTION
This change introduces new unit tests for modules within the `tsercom/util` and `tsercom/timesync` directories to improve your test coverage.

Key accomplishments:
- Added tests for `tsercom/util/stopable.py` (ABC contracts).
- Added tests for `tsercom/util/is_running_tracker.py`, focusing on synchronous logic and mocked async interactions due to environmental issues with `pytest-asyncio`'s `event_loop` fixture. Full asynchronous behavior testing for this module was impacted.
- Added comprehensive tests for modules in `tsercom/timesync/common/`:
    - `synchronized_timestamp.py`
    - `fake_synchronized_clock.py`
    - `synchronized_clock.py` (ABC contracts)
- Added tests for modules in `tsercom/timesync/client/`:
    - `client_synchronized_clock.py`
    - `fake_time_sync_client.py`
- Enhanced existing tests for `tsercom/timesync/client/time_sync_client.py`.
- Added tests for `tsercom/timesync/server/server_synchronized_clock.py`.
- Added a comprehensive test suite for `tsercom/timesync/server/time_sync_server.py`, including tests for its asynchronous server loop and NTP packet handling logic.

Copyright headers were removed from new and modified test files as you requested. I performed code quality checks using `black` and `ruff`.

The final verification was skipped as per your request. There were some initial issues with incorrect directory paths during the (aborted) verification phase.