### PR TITLE
Fix: Correct exception type for SynchronizedTimestamp comparisons

### DIFF
--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev1+g7c7ada8.d20250531"
+__version__ = "0.1.dev1+ga8f50f7.d20250601"

--- a/tsercom/api/local_process/local_runtime_factory.py
+++ b/tsercom/api/local_process/local_runtime_factory.py
@@ -7,7 +7,7 @@ from tsercom.api.local_process.runtime_command_bridge import (
 )
 from tsercom.data.annotated_instance import AnnotatedInstance
 from tsercom.data.event_instance import EventInstance
-from tsercom.data.exposed_data import ExposedData # Added import
+from tsercom.data.exposed_data import ExposedData  # Added import
 from tsercom.data.remote_data_reader import RemoteDataReader
 from tsercom.rpc.grpc_util.grpc_channel_factory import GrpcChannelFactory
 from tsercom.runtime.runtime import Runtime
@@ -18,7 +18,7 @@ from tsercom.threading.async_poller import AsyncPoller
 from tsercom.threading.thread_watcher import ThreadWatcher
 
 TEventType = TypeVar("TEventType")
-TDataType = TypeVar("TDataType", bound=ExposedData) # Constrained TDataType
+TDataType = TypeVar("TDataType", bound=ExposedData)  # Constrained TDataType
 
 
 class LocalRuntimeFactory(

--- a/tsercom/api/local_process/local_runtime_factory_factory.py
+++ b/tsercom/api/local_process/local_runtime_factory_factory.py
@@ -2,7 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 from typing import TypeVar, Tuple
-from tsercom.data.exposed_data import ExposedData # Added import
+from tsercom.data.exposed_data import ExposedData  # Added import
 from tsercom.api.local_process.runtime_command_bridge import (
     RuntimeCommandBridge,
 )
@@ -17,7 +17,7 @@ from tsercom.runtime.runtime_initializer import RuntimeInitializer
 from tsercom.threading.async_poller import AsyncPoller
 
 # Type variables for generic typing
-TDataType = TypeVar("TDataType", bound=ExposedData) # Constrained TDataType
+TDataType = TypeVar("TDataType", bound=ExposedData)  # Constrained TDataType
 TEventType = TypeVar("TEventType")
 
 

--- a/tsercom/api/runtime_factory_factory.py
+++ b/tsercom/api/runtime_factory_factory.py
@@ -3,13 +3,13 @@
 from abc import ABC, abstractmethod
 from typing import TypeVar, Tuple, Generic
 
-from tsercom.data.exposed_data import ExposedData # Added import
+from tsercom.data.exposed_data import ExposedData  # Added import
 from tsercom.api.runtime_handle import RuntimeHandle
 from tsercom.runtime.runtime_factory import RuntimeFactory
 from tsercom.runtime.runtime_initializer import RuntimeInitializer
 
 # Type variable for data, typically bound by some base data class.
-TDataType = TypeVar("TDataType", bound=ExposedData) # Constrained TDataType
+TDataType = TypeVar("TDataType", bound=ExposedData)  # Constrained TDataType
 # Type variable for events.
 TEventType = TypeVar("TEventType")
 
@@ -22,7 +22,7 @@ class RuntimeFactoryFactory(ABC, Generic[TDataType, TEventType]):
     It uses a client callback mechanism to notify when a handle is ready.
     """
 
-    class Client: # Removed Generic[TDataType, TEventType]
+    class Client:  # Removed Generic[TDataType, TEventType]
         """Interface for clients of RuntimeFactoryFactory.
 
         Clients implement this interface to receive notifications when a
@@ -67,7 +67,7 @@ class RuntimeFactoryFactory(ABC, Generic[TDataType, TEventType]):
 
     def create_factory(
         self,
-        client: "RuntimeFactoryFactory.Client", # Removed [TDataType, TEventType]
+        client: "RuntimeFactoryFactory.Client",  # Removed [TDataType, TEventType]
         initializer: RuntimeInitializer[TDataType, TEventType],
     ) -> RuntimeFactory[TDataType, TEventType]:
         """Creates a RuntimeFactory and notifies the client when its handle is ready.

--- a/tsercom/api/runtime_manager.py
+++ b/tsercom/api/runtime_manager.py
@@ -23,7 +23,7 @@ from tsercom.api.runtime_manager_helpers import (
 from tsercom.api.split_process.split_process_error_watcher_source import (
     SplitProcessErrorWatcherSource,  # Keep for type hinting if necessary
 )
-from tsercom.data.exposed_data import ExposedData # Added import
+from tsercom.data.exposed_data import ExposedData  # Added import
 from tsercom.runtime.runtime_factory import RuntimeFactory
 from tsercom.runtime.runtime_initializer import RuntimeInitializer
 
@@ -44,7 +44,7 @@ from tsercom.threading.thread_watcher import ThreadWatcher
 from tsercom.util.is_running_tracker import IsRunningTracker
 
 # Type variables for generic RuntimeHandle and related classes.
-TDataType = TypeVar("TDataType", bound=ExposedData) # Constrained TDataType
+TDataType = TypeVar("TDataType", bound=ExposedData)  # Constrained TDataType
 TEventType = TypeVar("TEventType")
 
 
@@ -427,7 +427,7 @@ class RuntimeManager(ErrorWatcher):
 
 
 class RuntimeFuturePopulator(
-    RuntimeFactoryFactory.Client, # Removed [TDataType, TEventType]
+    RuntimeFactoryFactory.Client,  # Removed [TDataType, TEventType]
     Generic[TDataType, TEventType],
 ):
     """A client that populates a Future with a RuntimeHandle when ready.

--- a/tsercom/api/split_process/split_runtime_factory_factory.py
+++ b/tsercom/api/split_process/split_runtime_factory_factory.py
@@ -2,7 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 from typing import TypeVar, Tuple
-from tsercom.data.exposed_data import ExposedData # Added import
+from tsercom.data.exposed_data import ExposedData  # Added import
 from tsercom.api.runtime_factory_factory import RuntimeFactoryFactory
 from tsercom.api.runtime_handle import RuntimeHandle
 from tsercom.api.split_process.remote_runtime_factory import (

--- a/tsercom/data/remote_data_aggregator.py
+++ b/tsercom/data/remote_data_aggregator.py
@@ -24,7 +24,7 @@ class RemoteDataAggregator(ABC, Generic[TDataType]):
     availability and new endpoint discovery.
     """
 
-    class Client(ABC): # Removed Generic[TDataType]
+    class Client(ABC):  # Removed Generic[TDataType]
         """Interface for clients wishing to receive callbacks from a RemoteDataAggregator.
 
         Implementers of this interface can register with a `RemoteDataAggregator`

--- a/tsercom/data/remote_data_aggregator_impl.py
+++ b/tsercom/data/remote_data_aggregator_impl.py
@@ -40,14 +40,18 @@ class RemoteDataAggregatorImpl(
     def __init__(
         self,
         thread_pool: ThreadPoolExecutor,
-        client: Optional[RemoteDataAggregator.Client] = None, # Removed [TDataType]
+        client: Optional[
+            RemoteDataAggregator.Client
+        ] = None,  # Removed [TDataType]
     ): ...
 
     @overload
     def __init__(
         self,
         thread_pool: ThreadPoolExecutor,
-        client: Optional[RemoteDataAggregator.Client] = None, # Removed [TDataType]
+        client: Optional[
+            RemoteDataAggregator.Client
+        ] = None,  # Removed [TDataType]
         *,
         tracker: DataTimeoutTracker,
     ): ...
@@ -56,7 +60,9 @@ class RemoteDataAggregatorImpl(
     def __init__(
         self,
         thread_pool: ThreadPoolExecutor,
-        client: Optional[RemoteDataAggregator.Client] = None, # Removed [TDataType]
+        client: Optional[
+            RemoteDataAggregator.Client
+        ] = None,  # Removed [TDataType]
         *,
         timeout: int,
     ): ...
@@ -64,7 +70,9 @@ class RemoteDataAggregatorImpl(
     def __init__(
         self,
         thread_pool: ThreadPoolExecutor,
-        client: Optional[RemoteDataAggregator.Client] = None, # Removed [TDataType]
+        client: Optional[
+            RemoteDataAggregator.Client
+        ] = None,  # Removed [TDataType]
         *,
         tracker: Optional[DataTimeoutTracker] = None,
         timeout: Optional[int] = None,
@@ -99,8 +107,8 @@ class RemoteDataAggregatorImpl(
             tracker.start()
 
         self.__thread_pool: ThreadPoolExecutor = thread_pool
-        self.__client: Optional[RemoteDataAggregator.Client] = ( # Removed [TDataType]
-            client
+        self.__client: Optional[RemoteDataAggregator.Client] = (
+            client  # Removed [TDataType]
         )
         self.__tracker: Optional[DataTimeoutTracker] = tracker
 

--- a/tsercom/discovery/mdns/instance_listener.py
+++ b/tsercom/discovery/mdns/instance_listener.py
@@ -30,7 +30,7 @@ class InstanceListener(Generic[TServiceInfo], MdnsListener.Client):
     and notifies its registered `Client` about the newly discovered service instance.
     """
 
-    class Client(ABC): # Removed Generic[TServiceInfo]
+    class Client(ABC):  # Removed Generic[TServiceInfo]
         """Interface for clients of `InstanceListener`.
 
         Implementers of this interface are notified when a complete service
@@ -55,7 +55,7 @@ class InstanceListener(Generic[TServiceInfo], MdnsListener.Client):
 
     def __init__(
         self,
-        client: "InstanceListener.Client", # Removed [TServiceInfo]
+        client: "InstanceListener.Client",  # Removed [TServiceInfo]
         service_type: str,
         *,
         mdns_listener_factory: Optional[
@@ -91,7 +91,9 @@ class InstanceListener(Generic[TServiceInfo], MdnsListener.Client):
                 f"service_type must be a string, got {type(service_type).__name__}."
             )
 
-        self.__client: InstanceListener.Client = client # Removed [TServiceInfo]
+        self.__client: InstanceListener.Client = (
+            client  # Removed [TServiceInfo]
+        )
         # This InstanceListener acts as the client to the MdnsListener.
 
         self.__listener: MdnsListener  # Declare type once for __listener

--- a/tsercom/discovery/mdns/instance_listener_unittest.py
+++ b/tsercom/discovery/mdns/instance_listener_unittest.py
@@ -75,7 +75,9 @@ FClientServiceInfo = TypeVar("FClientServiceInfo", bound=ServiceInfo)
 
 # InstanceListener.Client is now Generic[TServiceInfo], so FakeInstanceListenerClient
 # just needs to inherit from it with its specific type var.
-class FakeInstanceListenerClient(InstanceListener.Client, Generic[FClientServiceInfo]): # Made FakeInstanceListenerClient generic
+class FakeInstanceListenerClient(
+    InstanceListener.Client, Generic[FClientServiceInfo]
+):  # Made FakeInstanceListenerClient generic
     def __init__(self):
         # _on_service_added_mock is an AsyncMock to spy on the _on_service_added method.
         self._on_service_added_mock: AsyncMock = AsyncMock()

--- a/tsercom/runtime/client/client_runtime_data_handler.py
+++ b/tsercom/runtime/client/client_runtime_data_handler.py
@@ -7,7 +7,7 @@ for Tsercom runtimes operating in a client role.
 
 from typing import Generic, TypeVar
 from tsercom.data.annotated_instance import AnnotatedInstance
-from tsercom.data.exposed_data import ExposedData # Added import
+from tsercom.data.exposed_data import ExposedData  # Added import
 from tsercom.data.remote_data_reader import RemoteDataReader
 from tsercom.data.serializable_annotated_instance import (
     SerializableAnnotatedInstance,
@@ -23,7 +23,7 @@ from tsercom.threading.thread_watcher import ThreadWatcher
 
 
 TEventType = TypeVar("TEventType")
-TDataType = TypeVar("TDataType", bound=ExposedData) # Constrained TDataType
+TDataType = TypeVar("TDataType", bound=ExposedData)  # Constrained TDataType
 
 
 class ClientRuntimeDataHandler(

--- a/tsercom/timesync/common/synchronized_timestamp.py
+++ b/tsercom/timesync/common/synchronized_timestamp.py
@@ -75,7 +75,7 @@ class SynchronizedTimestamp:
         else:
             other_dt = other
         if not isinstance(other_dt, datetime.datetime):
-            raise TypeError(
+            raise AssertionError(
                 f"Comparison is only supported with SynchronizedTimestamp or datetime.datetime, got {type(other_dt)}"
             )
         return self.as_datetime() > other_dt
@@ -86,7 +86,7 @@ class SynchronizedTimestamp:
         else:
             other_dt = other
         if not isinstance(other_dt, datetime.datetime):
-            raise TypeError(
+            raise AssertionError(
                 f"Comparison is only supported with SynchronizedTimestamp or datetime.datetime, got {type(other_dt)}"
             )
         return self.as_datetime() >= other_dt
@@ -97,7 +97,7 @@ class SynchronizedTimestamp:
         else:
             other_dt = other
         if not isinstance(other_dt, datetime.datetime):
-            raise TypeError(
+            raise AssertionError(
                 f"Comparison is only supported with SynchronizedTimestamp or datetime.datetime, got {type(other_dt)}"
             )
         return self.as_datetime() < other_dt
@@ -108,7 +108,7 @@ class SynchronizedTimestamp:
         else:
             other_dt = other
         if not isinstance(other_dt, datetime.datetime):
-            raise TypeError(
+            raise AssertionError(
                 f"Comparison is only supported with SynchronizedTimestamp or datetime.datetime, got {type(other_dt)}"
             )
         return self.as_datetime() <= other_dt


### PR DESCRIPTION
- Modified `SynchronizedTimestamp` comparison methods (`__gt__`, `__ge__`, `__lt__`, `__le__`) to raise `AssertionError` instead of `TypeError` when an invalid type is encountered for comparison. This aligns the behavior with the expectations of `test_comparison_invalid_type_raises_assertion_error` in `synchronized_timestamp_unittest.py`.
- The specific unit test for this case now passes.
- Verified E2E stability by running `runtime_e2etest.py` and `grpc_e2etest.py` after the fix; both suites passed without issues.
- Applied `black` formatting and `ruff` linting across the codebase during final verification.
- Confirmed the full test suite (ignoring `serializable_tensor_unittest.py`) passes reliably across two consecutive runs.