### PR TITLE
Fix: Resolve NonUniqueNameException in discovery E2E test

### DIFF
--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev1+g019dadf.d20250601"
+__version__ = '0.1.dev1+gc28c7e8.d20250601'

--- a/tsercom/discovery_e2etest.py
+++ b/tsercom/discovery_e2etest.py
@@ -4,7 +4,7 @@ import ipaddress
 import gc  # Moved import gc to top level
 
 import pytest
-import pytest_asyncio # Import pytest_asyncio
+import pytest_asyncio  # Import pytest_asyncio
 
 # pytest_asyncio is not directly imported but used via pytest.mark.asyncio
 from tsercom.threading.aio.global_event_loop import (
@@ -77,7 +77,7 @@ async def test_successful_registration_and_discovery():
         # Explicitly delete to manage lifecycle and satisfy linters,
         # relying on __del__ in publisher for unpublishing.
         if publisher_obj:
-            await publisher_obj.close() # Explicitly close
+            await publisher_obj.close()  # Explicitly close
         if (
             listener_obj
         ):  # listener_obj is always created if this block is reached
@@ -152,9 +152,7 @@ async def test_instance_update_reflects_changes():
     client = UpdateTestClient(
         [discovery_event1, discovery_event2], discovered_services
     )
-    listener_obj = InstanceListener(
-        client=client, service_type=service_type
-    )
+    listener_obj = InstanceListener(client=client, service_type=service_type)
 
     publisher1_obj = None  # Initialize for finally block
     publisher2_obj = None  # Initialize for finally block
@@ -187,6 +185,13 @@ async def test_instance_update_reflects_changes():
         service_port2 = 50003
         readable_name2 = f"UpdateTestService_V2_{service_type_suffix}"
 
+        # Explicitly close the first publisher to unregister its service
+        # so the second publisher can register the same instance name.
+        if publisher1_obj:
+            await publisher1_obj.close()
+            # Allow a brief moment for the unregistration to propagate.
+            await asyncio.sleep(0.2)
+
         publisher2_obj = InstancePublisher(
             port=service_port2,
             service_type=service_type,
@@ -209,9 +214,9 @@ async def test_instance_update_reflects_changes():
             pytest.fail(f"A timeout error occurred: {e}")
     finally:
         if publisher1_obj:
-            await publisher1_obj.close() # Explicitly close
+            await publisher1_obj.close()  # Explicitly close
         if publisher2_obj:
-            await publisher2_obj.close() # Explicitly close
+            await publisher2_obj.close()  # Explicitly close
         if listener_obj:  # listener_obj is always created
             del listener_obj
         gc.collect()  # Encourage faster cleanup
@@ -297,7 +302,7 @@ async def test_instance_unpublishing():
 
     # Phase 2: "Unpublish" the service
     # Explicitly close the publisher to unregister the service.
-    if publisher: # Ensure publisher was created
+    if publisher:  # Ensure publisher was created
         await publisher.close()
     # import gc # gc is now imported at top level
     gc.collect()  # GC still useful for other objects
@@ -438,7 +443,7 @@ async def test_multiple_publishers_one_listener():
             f"Not all services ({len(expected_service_details)}) discovered within timeout. Found {len(discovered_services)}."
         )
     finally:
-        for p in publishers: # Close all publishers
+        for p in publishers:  # Close all publishers
             if p:
                 await p.close()
         del listener


### PR DESCRIPTION
The test `tsercom/discovery_e2etest.py::test_instance_update_reflects_changes` was failing due to a `zeroconf._exceptions.NonUniqueNameException`. This occurred because the test attempted to publish a new mDNS service instance with the same instance name as a previously published service, without unregistering the first one.

The fix involves explicitly closing the first `InstancePublisher` (publisher1_obj) before the second one (`publisher2_obj`) attempts to publish its service with the identical instance name. A small delay (`asyncio.sleep(0.2)`) was added after closing the first publisher to allow time for the mDNS unregistration to propagate before the second registration attempt.

This change ensures that the mDNS instance name is unique at the point of registration for the second publisher, resolving the exception.

Verification:
- The specific failing test `test_instance_update_reflects_changes` now passes.
- All other E2E tests (`runtime_e2etest.py`, `rpc_e2etest.py`) continue to pass, indicating no regressions.
- Code quality checks (`black`, `ruff`) have been applied to the modified file.
- Two full test suite runs (ignoring `serializable_tensor_unittest.py`) confirmed that all 519 relevant tests pass consistently.