### PR TITLE
Fix: Resolve all remaining mypy type checking errors

### DIFF
--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev1+gc28c7e8.d20250601"
+__version__ = "0.1.dev1+g7d25bb3.d20250601"

--- a/tsercom/discovery/mdns/instance_publisher.py
+++ b/tsercom/discovery/mdns/instance_publisher.py
@@ -164,7 +164,7 @@ class InstancePublisher:
         ):
             try:
                 # Assuming the close method of the publisher is async
-                await self.__record_publisher.close()  # type: ignore
+                await self.__record_publisher.close()
             except Exception as e:
                 _logger.error(
                     "Error while closing the record publisher: %s",

--- a/tsercom/discovery/mdns/mdns_publisher.py
+++ b/tsercom/discovery/mdns/mdns_publisher.py
@@ -11,7 +11,7 @@ class MdnsPublisher(ABC):
     """
 
     @abstractmethod
-    def publish(self) -> None:
+    async def publish(self) -> None:
         """Publishes the service instance via mDNS.
 
         Implementations should handle the necessary steps to make the service


### PR DESCRIPTION
This commit addresses all outstanding mypy errors in your tsercom/ codebase.

The following key changes were made to achieve a clean mypy run:
- Installed `types-psutil` to provide type stubs for the `psutil` library.
- Modified `tsercom/discovery/mdns/mdns_publisher.py`: The `publish` method in the `MdnsPublisher` abstract base class was changed to `async def publish(self) -> None:`. This aligns its signature with the asynchronous implementation in the `RecordPublisher` subclass, resolving a mypy incompatibility error.
- Removed an unused `# type: ignore` comment from `tsercom/discovery/mdns/instance_publisher.py`.

No new `# type: ignore` directives were added as part of these fixes.

Verification steps I performed:
1. I confirmed that `mypy tsercom/` now reports "Success: no issues found".
2. I ensured that code formatting and linting checks (`black` and `ruff`) pass.
3. I verified that the full test suite (`pytest --timeout=120 --ignore=tsercom/rpc/serialization/serializable_tensor_unittest.py`) passes consistently across two runs, confirming no functional regressions.