### PR TITLE
Fix/test uncomment and warnings

### DIFF
--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev1+geb2b514.d20250606"
+__version__ = '0.1.dev1+g30dc82e.d20250606'

--- a/tsercom/_version.py
+++ b/tsercom/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.dev1+g30dc82e.d20250606'
+__version__ = "0.1.dev1+g30dc82e.d20250606"

--- a/tsercom/api/runtime_manager_unittest.py
+++ b/tsercom/api/runtime_manager_unittest.py
@@ -519,7 +519,9 @@ class TestRuntimeManager:
                 factory_mock.auth_config = None
 
                 mock_runtime_on_factory = MagicMock()
-                mock_runtime_on_factory.start_async = AsyncMock(return_value=None)
+                mock_runtime_on_factory.start_async = AsyncMock(
+                    return_value=None
+                )
                 factory_mock.create.return_value = mock_runtime_on_factory
                 return factory_mock
 

--- a/tsercom/api/runtime_manager_unittest.py
+++ b/tsercom/api/runtime_manager_unittest.py
@@ -34,11 +34,6 @@ import tsercom.threading.aio.global_event_loop as gev_loop
 # Import for auth_config
 
 
-async def dummy_coroutine_for_test():
-    """A simple coroutine that does nothing, for mocking awaitables."""
-    pass
-
-
 @pytest.fixture
 def mock_thread_watcher(mocker):
     mock = mocker.MagicMock(spec=ThreadWatcher)
@@ -247,9 +242,7 @@ class TestRuntimeManager:
             mock_factory_instance.auth_config = None
 
             mock_runtime_on_factory = MagicMock()
-            mock_runtime_on_factory.start_async = AsyncMock(
-                return_value=dummy_coroutine_for_test()
-            )
+            mock_runtime_on_factory.start_async = AsyncMock(return_value=None)
             mock_factory_instance.create.return_value = mock_runtime_on_factory
 
             mock_local_rff.create_factory.return_value = mock_factory_instance
@@ -526,9 +519,7 @@ class TestRuntimeManager:
                 factory_mock.auth_config = None
 
                 mock_runtime_on_factory = MagicMock()
-                mock_runtime_on_factory.start_async = AsyncMock(
-                    return_value=dummy_coroutine_for_test()
-                )
+                mock_runtime_on_factory.start_async = AsyncMock(return_value=None)
                 factory_mock.create.return_value = mock_runtime_on_factory
                 return factory_mock
 

--- a/tsercom/data/data_host_base.py
+++ b/tsercom/data/data_host_base.py
@@ -57,7 +57,7 @@ class DataHostBase(
 
         # Assign to a local variable first, then to self.__aggregator to avoid redefinition error.
         aggregator_instance: RemoteDataAggregatorImpl[DataTypeT]
-        self.__tracker: Optional[DataTimeoutTracker] = tracker # Store tracker
+        self.__tracker: Optional[DataTimeoutTracker] = tracker  # Store tracker
 
         if self.__tracker is not None:
             aggregator_instance = RemoteDataAggregatorImpl[DataTypeT](
@@ -74,8 +74,8 @@ class DataHostBase(
     def close(self) -> None:
         """Stops the data timeout tracker if it was started."""
         if self.__tracker is not None:
-            self.__tracker.stop() # Changed from await to direct call
-            self.__tracker = None # Clear after stopping
+            self.__tracker.stop()  # Changed from await to direct call
+            self.__tracker = None  # Clear after stopping
 
     def _on_data_ready(self, new_data: DataTypeT) -> None:
         """Handles new data by passing it to the internal data aggregator.

--- a/tsercom/data/remote_data_aggregator_impl.py
+++ b/tsercom/data/remote_data_aggregator_impl.py
@@ -109,6 +109,20 @@ class RemoteDataAggregatorImpl(
         ] = {}
         self.__lock: threading.Lock = threading.Lock()
 
+    def close(self) -> None:
+        """Stops the internal DataTimeoutTracker if it was created and started by this instance."""
+        if self.__tracker is not None:
+            # Check if this instance of RemoteDataAggregatorImpl actually created the tracker.
+            # This is a heuristic; if tracker was passed in, this instance is not its owner.
+            # A more robust way would be to have an internal flag, e.g., self.__owns_tracker.
+            # For now, we assume if self.__tracker exists, it might need stopping by this instance.
+            # The DataTimeoutTracker.stop() method itself is idempotent.
+            self.__tracker.stop() # Changed from await to direct call
+            # We might not want to set self.__tracker to None if it was passed in,
+            # as the owner might still need it. However, if we created it, clearing is fine.
+            # For simplicity in this refactor, let's assume if we stop it, we are done with it here.
+            # self.__tracker = None # Decided against clearing if it could be externally owned.
+
     def stop(
         self, identifier: Optional[CallerIdentifier] = None
     ) -> None:  # Renamed id to identifier

--- a/tsercom/data/remote_data_aggregator_impl.py
+++ b/tsercom/data/remote_data_aggregator_impl.py
@@ -117,7 +117,7 @@ class RemoteDataAggregatorImpl(
             # A more robust way would be to have an internal flag, e.g., self.__owns_tracker.
             # For now, we assume if self.__tracker exists, it might need stopping by this instance.
             # The DataTimeoutTracker.stop() method itself is idempotent.
-            self.__tracker.stop() # Changed from await to direct call
+            self.__tracker.stop()  # Changed from await to direct call
             # We might not want to set self.__tracker to None if it was passed in,
             # as the owner might still need it. However, if we created it, clearing is fine.
             # For simplicity in this refactor, let's assume if we stop it, we are done with it here.

--- a/tsercom/runtime/endpoint_data_processor_unittest.py
+++ b/tsercom/runtime/endpoint_data_processor_unittest.py
@@ -17,7 +17,7 @@ DataTypeT = TypeVar("DataTypeT")
 EventTypeT = TypeVar("EventTypeT")
 
 
-class ConcreteTestProcessor(
+class MockEndpointProcessor(
     Generic[DataTypeT, EventTypeT],
     EndpointDataProcessor[DataTypeT, EventTypeT],
 ):
@@ -69,7 +69,7 @@ def mock_caller_id():
 @pytest.fixture
 def processor(mock_caller_id, mocker):
     # Use object as a simple placeholder for DataTypeT and EventTypeT if not specified
-    return ConcreteTestProcessor[object, object](mock_caller_id, mocker)
+    return MockEndpointProcessor[object, object](mock_caller_id, mocker)
 
 
 @pytest.mark.asyncio

--- a/tsercom/runtime/runtime_main_unittest.py
+++ b/tsercom/runtime/runtime_main_unittest.py
@@ -584,7 +584,6 @@ class TestRemoteProcessMain:
                 "tsercom.runtime.runtime_main.get_global_event_loop"
             ).return_value
 
-
             remote_process_main(mock_factories, mock_error_queue)
 
             mock_clear_event_loop.assert_called_once()
@@ -638,7 +637,6 @@ class TestRemoteProcessMain:
             mocker.patch(  # Keep this if the loop instance is used for other assertions.
                 "tsercom.runtime.runtime_main.get_global_event_loop"
             ).return_value
-
 
             mock_error_queue = mocker.Mock(spec=MultiprocessQueueSink)
             queue_exception = Exception("Queue put failed")
@@ -699,7 +697,9 @@ class TestRemoteProcessMain:
 
             # Simulate some runtimes being initialized
             mock_runtime1 = mocker.AsyncMock(spec=Runtime)
-            mock_runtime1.stop = mocker.AsyncMock() # This is the coroutine we need awaited
+            mock_runtime1.stop = (
+                mocker.AsyncMock()
+            )  # This is the coroutine we need awaited
             mock_initialize_runtimes.return_value = [mock_runtime1]
 
             # Event loop is managed by pytest-asyncio and conftest.py
@@ -707,7 +707,6 @@ class TestRemoteProcessMain:
             mock_loop_instance = mocker.patch(
                 "tsercom.runtime.runtime_main.get_global_event_loop"
             ).return_value
-
 
             # Simulate a clean exit from the main try block to reach finally
             mock_sink_instance = MockSplitProcessErrorWatcherSink.return_value
@@ -768,16 +767,13 @@ class TestRemoteProcessMain:
                 "tsercom.runtime.runtime_main.initialize_runtimes"
             )
             # mock_run_on_event_loop is not used for stop logic
-            mocker.patch(
-                "tsercom.runtime.runtime_main.run_on_event_loop"
-            )
+            mocker.patch("tsercom.runtime.runtime_main.run_on_event_loop")
 
             # Event loop is managed by pytest-asyncio and conftest.py
             # Patch get_global_event_loop once and store the mock loop instance
             mock_loop_instance = mocker.patch(
                 "tsercom.runtime.runtime_main.get_global_event_loop"
             ).return_value
-
 
             mock_factories = [mocker.Mock(spec=RuntimeFactory)]
             mock_error_queue = mocker.Mock(spec=MultiprocessQueueSink)
@@ -816,8 +812,8 @@ class TestRemoteProcessMain:
             #     assert partial_obj.args == (None,)
             # assert actual_called_stop_funcs == expected_stop_funcs
             mock_initialize_runtimes.assert_called_once()
-            mock_runtime1.stop.assert_called_once() # Check the AsyncMocks were called
-            mock_runtime2.stop.assert_called_once() # Check the AsyncMocks were called
+            mock_runtime1.stop.assert_called_once()  # Check the AsyncMocks were called
+            mock_runtime2.stop.assert_called_once()  # Check the AsyncMocks were called
             # The call_count assertion for create_task has been removed as it was problematic
             # and the core behavior is verified by checking if stop() was called on runtimes.
         finally:

--- a/tsercom/runtime_e2etest.py
+++ b/tsercom/runtime_e2etest.py
@@ -90,6 +90,8 @@ class FakeRuntime(Runtime):
     async def stop(self, exception) -> None:
         assert self.__responder is not None
         await self.__responder.process_data(FakeData(stopped), stop_timestamp)
+        if hasattr(self.__data_handler, 'close') and callable(self.__data_handler.close):
+            await self.__data_handler.close()
 
 
 class FakeRuntimeInitializer(RuntimeInitializer[FakeData, FakeEvent]):

--- a/tsercom/runtime_e2etest.py
+++ b/tsercom/runtime_e2etest.py
@@ -90,7 +90,9 @@ class FakeRuntime(Runtime):
     async def stop(self, exception) -> None:
         assert self.__responder is not None
         await self.__responder.process_data(FakeData(stopped), stop_timestamp)
-        if hasattr(self.__data_handler, 'close') and callable(self.__data_handler.close):
+        if hasattr(self.__data_handler, "close") and callable(
+            self.__data_handler.close
+        ):
             await self.__data_handler.close()
 
 

--- a/tsercom/timesync/client/time_sync_client_unittest.py
+++ b/tsercom/timesync/client/time_sync_client_unittest.py
@@ -284,37 +284,37 @@ class TestTimeSyncClientOperations:
         assert client.get_offset_seconds() == pytest.approx(first_offset)
         assert client._TimeSyncClient__start_barrier.is_set()
 
-    # def test_assertion_error_in_loop_calls_watcher_and_stops_loop(
-    #     self,
-    #     client: TimeSyncClient,
-    #     mock_ntp_client_fixture,
-    #     mock_thread_watcher_fixture,
-    # ):
-    #     test_exception = AssertionError("Test assertion in loop")
-    #     mock_ntp_client_fixture.request.side_effect = test_exception
-    #     client.start_async()
-    #     max_wait_cycles = 10
-    #     cycles = 0
-    #     while (
-    #         mock_thread_watcher_fixture.on_exception_seen.call_count == 0
-    #         and cycles < max_wait_cycles
-    #     ):
-    #         time.sleep(0.1)
-    #         cycles += 1
-    #     mock_thread_watcher_fixture.on_exception_seen.assert_called_once_with(
-    #         test_exception
-    #     )
-    #     sync_loop_thread = client._TimeSyncClient__sync_loop_thread
-    #     if sync_loop_thread:
-    #         sync_loop_thread.join(timeout=1.0)
-    #         assert (
-    #             not sync_loop_thread.is_alive()
-    #         ), "Sync loop thread should be dead."
-    #     assert (
-    #         client.is_running()
-    #     ), "is_running is True as loop crash doesn't call client.stop()."
-    #     client.stop()
-    #     assert not client.is_running()
+    def test_assertion_error_in_loop_calls_watcher_and_stops_loop(
+        self,
+        client: TimeSyncClient,
+        mock_ntp_client_fixture,
+        mock_thread_watcher_fixture,
+    ):
+        test_exception = AssertionError("Test assertion in loop")
+        mock_ntp_client_fixture.request.side_effect = test_exception
+        client.start_async()
+        max_wait_cycles = 10
+        cycles = 0
+        while (
+            mock_thread_watcher_fixture.on_exception_seen.call_count == 0
+            and cycles < max_wait_cycles
+        ):
+            time.sleep(0.1)
+            cycles += 1
+        mock_thread_watcher_fixture.on_exception_seen.assert_called_once_with(
+            test_exception
+        )
+        sync_loop_thread = client._TimeSyncClient__sync_loop_thread
+        if sync_loop_thread:
+            sync_loop_thread.join(timeout=1.0)
+            assert (
+                not sync_loop_thread.is_alive()
+            ), "Sync loop thread should be dead."
+        assert (
+            client.is_running()
+        ), "is_running is True as loop crash doesn't call client.stop()."
+        client.stop()
+        assert not client.is_running()
 
     def test_general_exception_in_loop_logs_and_continues(
         self, client: TimeSyncClient, mock_ntp_client_fixture, mocker


### PR DESCRIPTION
Phase 1: Fixed Commented-Out Test
- I located and uncommented `test_assertion_error_in_loop_calls_watcher_and_stops_loop`
  in `tsercom/timesync/client/time_sync_client_unittest.py`.
- I found the test to be passing after uncommenting; I reviewed its logic
  and deemed it correct in relation to the current application code.

Phase 2: Pytest Warnings and Test Health
- I addressed several `RuntimeWarning`s and one `PytestCollectionWarning`:
  - I resolved the `PytestCollectionWarning` in `endpoint_data_processor_unittest.py`
    by renaming a helper class.
  - I resolved the `RuntimeWarning` for `dummy_coroutine_for_test` in
    `runtime_manager_unittest.py` by removing the dummy and using `AsyncMock(return_value=None)`.
  - I resolved the `RuntimeWarning` for `AsyncMockMixin._execute_mock_call` in
    `runtime_main_unittest.py` by ensuring real asyncio tasks were used for
    `AsyncMock`ed methods, removing faulty mock interference.
  - I resolved the `RuntimeWarning` for `RuntimeDataHandlerBase.__dispatch_poller_data_loop`
    (one instance) by refactoring `RuntimeDataHandlerBase.__init__` to
    conditionally schedule its background task and improving its `close()` method.
  - I resolved the `RuntimeWarning` for `DataTimeoutTracker.__execute_periodically`
    by refactoring `DataTimeoutTracker.stop()` to be synchronous but more robustly
    signal and cancel its background task, and updating callers
    (`RemoteDataAggregatorImpl`, `DataHostBase`) to use this synchronous stop.
    This also involved fixing a `TypeError: 'bool' object is not callable` in
    `DataTimeoutTracker.start()`.
- I updated `FakeRuntime.stop()` in E2E tests to call `data_handler.close()`.
- I updated `RemoteDataAggregatorImpl.close()` and `DataHostBase.close()` to be synchronous
  and call the updated synchronous `DataTimeoutTracker.stop()`.

All 607 tests are passing (1 skipped).