### PR TITLE
Add test for MdnsListener subclass instantiation

### DIFF
--- a/tsercom/discovery/mdns/mdns_listener_unittest.py
+++ b/tsercom/discovery/mdns/mdns_listener_unittest.py
@@ -1,0 +1,58 @@
+# Filename: tsercom/discovery/mdns/mdns_listener_unittest.py
+from zeroconf import Zeroconf
+from tsercom.discovery.mdns.mdns_listener import MdnsListener
+
+# Use an alias for MdnsListener.Client for clarity in type hints
+from tsercom.discovery.mdns.mdns_listener import (
+    MdnsListener as IMdnsListenerClientProto,
+)
+
+
+# A mock client for the listener, conforming to MdnsListener.Client interface
+class MockMdnsClient(IMdnsListenerClientProto.Client):
+    def _on_service_added(
+        self,
+        name: str,
+        port: int,
+        addresses: list[bytes],
+        txt_record: dict[bytes, bytes | None],
+    ) -> None:
+        pass
+
+    def _on_service_removed(
+        self, name: str, service_type: str, record_listener_uuid: str
+    ) -> None:
+        pass
+
+
+class FaultyCustomListener(MdnsListener):
+    def __init__(
+        self, client: IMdnsListenerClientProto.Client, service_type: str
+    ):
+        # This call was initially expected to trigger a TypeError, but none occurs in the current codebase.
+        super().__init__()
+        self._client = client
+        self._service_type = service_type
+
+    # Required ABC methods for instantiation
+    def start(self) -> None:
+        pass
+
+    def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        pass
+
+    def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        pass
+
+    def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        pass
+
+
+def test_custom_listener_instantiation_failure() -> None:
+    mock_client = MockMdnsClient()
+    service_type = "_test_service._tcp.local."
+
+    # This test now confirms that FaultyCustomListener can be instantiated without a TypeError.
+    # The pytest.raises block below was commented out as the TypeError was not observed.
+    # with pytest.raises(TypeError, match=r"(__init__\(\) takes exactly one argument)|(takes 1 positional argument but .* were given)|(object.__init__\(\) takes no parameters)"):
+    _ = FaultyCustomListener(mock_client, service_type)


### PR DESCRIPTION
This commit introduces a new test file, `tsercom/discovery/mdns/mdns_listener_unittest.py`, with a test case `test_custom_listener_instantiation_failure`.

The initial goal was to investigate and fix a reported `TypeError` when subclassing `MdnsListener` and calling `super().__init__()`. However, this `TypeError` was not reproducible with the current codebase.

The new test confirms that `MdnsListener` can be subclassed and `super().__init__()` can be called from the subclass's `__init__` method without raising a `TypeError`. Comments in the test file have been updated to reflect this finding.

The process involved:
- Setting up the environment.
- Adding the test case to the new file.
- Verifying that the test passed (indicating no TypeError).
- Skipping application code changes as no bug was found.
- Ensuring the test passed static analysis and all suite tests.