### PR TITLE
Refactor: Use torch.Tensor for keyframe storage in SmoothedTensorDemuxer

### DIFF
--- a/tsercom/data/tensor/linear_interpolation_strategy.py
+++ b/tsercom/data/tensor/linear_interpolation_strategy.py
@@ -1,79 +1,181 @@
-import bisect
-from datetime import datetime
-from typing import List, Tuple, Union
+import torch
 
-from tsercom.data.tensor.smoothing_strategy import (
-    SmoothingStrategy,
-)  # Import ABC from its new file name
+from tsercom.data.tensor.smoothing_strategy import SmoothingStrategy
 
 
 class LinearInterpolationStrategy(SmoothingStrategy):
     """
-    Implements linear interpolation for a series of data points.
+    Implements linear interpolation for a series of data points using PyTorch tensors.
     """
 
     def interpolate_series(
         self,
-        keyframes: List[Tuple[datetime, float]],
-        required_timestamps: List[datetime],
-    ) -> List[Union[float, None]]:
+        timestamps: torch.Tensor,
+        values: torch.Tensor,
+        required_timestamps: torch.Tensor,
+    ) -> torch.Tensor:
         """
-        Performs linear interpolation for a given set of keyframes and required timestamps.
-
-        - If a required timestamp is before the first keyframe, the value of the
-          first keyframe is returned (extrapolation).
-        - If a required timestamp is after the last keyframe, the value of the
-          last keyframe is returned (extrapolation).
-        - If a required timestamp exactly matches a keyframe, the value of that
-          keyframe is returned.
-        - If there are no keyframes, all interpolated values will be None.
-        - If there is only one keyframe, its value is returned for all required
-          timestamps.
+        Performs linear interpolation using tensor operations.
 
         Args:
-            keyframes: A time-sorted list of (timestamp, value) tuples.
-            required_timestamps: A list of datetime objects for which values are needed.
-                                 It's assumed these are sorted for efficiency, though the
-                                 logic here processes them one by one independently.
+            timestamps: torch.Tensor: A 1D tensor of Unix timestamps (float64), sorted.
+            values: torch.Tensor: A 1D tensor of corresponding values (float32).
+            required_timestamps: torch.Tensor: A 1D tensor of Unix timestamps (float64)
+                               for which values are needed.
 
         Returns:
-            A list of interpolated float values or None, corresponding to each
-            required timestamp.
+            torch.Tensor: A 1D tensor of interpolated values (float32), same size as
+                          `required_timestamps`. Contains `float('nan')` where
+                          interpolation is not possible (e.g. no keyframes).
+                          Extrapolates using the first/last keyframe value if
+                          required timestamps are outside the keyframe range.
         """
-        if not keyframes:
-            return [None] * len(required_timestamps)
+        if (
+            not isinstance(timestamps, torch.Tensor)
+            or not isinstance(values, torch.Tensor)
+            or not isinstance(required_timestamps, torch.Tensor)
+        ):
+            raise TypeError("All inputs must be torch.Tensor objects.")
+        if (
+            timestamps.ndim != 1
+            or values.ndim != 1
+            or required_timestamps.ndim != 1
+        ):
+            raise ValueError("All input tensors must be 1D.")
+        if (
+            timestamps.dtype != torch.float64
+            or values.dtype != torch.float32
+            or required_timestamps.dtype != torch.float64
+        ):
+            raise ValueError(
+                "Input tensor dtypes do not match expected: timestamps (float64), values (float32), required_timestamps (float64)."
+            )
 
-        if len(keyframes) == 1:
-            return [keyframes[0][1]] * len(required_timestamps)
+        if timestamps.numel() == 0:
+            return torch.full_like(
+                required_timestamps, float("nan"), dtype=torch.float32
+            )
 
-        key_times, key_values = zip(*keyframes)
-        interpolated_results: List[Union[float, None]] = []
+        if timestamps.numel() == 1:
+            return torch.full_like(
+                required_timestamps, values[0].item(), dtype=torch.float32
+            )
 
-        for ts_req in required_timestamps:
-            if ts_req <= key_times[0]:
-                interpolated_results.append(key_values[0])
-                continue
-            if ts_req >= key_times[-1]:
-                interpolated_results.append(key_values[-1])
-                continue
+        # Initialize results with NaN, output dtype should be float32
+        interpolated_results = torch.full_like(
+            required_timestamps, float("nan"), dtype=torch.float32
+        )
 
-            idx = bisect.bisect_left(key_times, ts_req)
+        # Extrapolation for timestamps before the first keyframe
+        before_mask = required_timestamps <= timestamps[0]
+        interpolated_results[before_mask] = values[0].item()
 
-            if key_times[idx] == ts_req:
-                interpolated_results.append(key_values[idx])
-                continue
+        # Extrapolation for timestamps after the last keyframe
+        after_mask = required_timestamps >= timestamps[-1]
+        interpolated_results[after_mask] = values[-1].item()
 
-            t1, v1 = key_times[idx - 1], key_values[idx - 1]
-            t2, v2 = key_times[idx], key_values[idx]
+        # Interpolation for timestamps between the first and last keyframes
+        # Ensure strict inequality for interpolation range to avoid issues at boundaries already handled by extrapolation
+        interp_mask = (required_timestamps > timestamps[0]) & (
+            required_timestamps < timestamps[-1]
+        )
 
-            if (t2 - t1).total_seconds() == 0:
-                interpolated_value = v1
-            else:
-                proportion = (ts_req - t1).total_seconds() / (
-                    t2 - t1
-                ).total_seconds()
-                interpolated_value = v1 + proportion * (v2 - v1)
+        if torch.any(interp_mask):
+            relevant_req_ts = required_timestamps[interp_mask]
 
-            interpolated_results.append(interpolated_value)
+            # Find indices of right neighbors for each required timestamp in the interpolation range
+            # searchsorted will find the index where an element could be inserted to maintain order.
+            # For a timestamp ts_req, if ts_req is between timestamps[i] and timestamps[i+1],
+            # searchsorted(timestamps, ts_req) would give i+1 (if side='left')
+            # or i+1 (if side='right' and ts_req > timestamps[i]).
+            # We want right_indices such that timestamps[left_indices] <= relevant_req_ts < timestamps[right_indices]
+            # So, side='right' is appropriate here.
+            right_indices = torch.searchsorted(
+                timestamps, relevant_req_ts, side="right"
+            )
 
-        return interpolated_results
+            # Clamp right_indices to prevent going out of bounds if relevant_req_ts is equal to timestamps[-1]
+            # This should ideally not happen due to strict interp_mask, but good for safety.
+            right_indices = torch.clamp(
+                right_indices, 1, timestamps.numel() - 1
+            )
+            left_indices = right_indices - 1
+
+            # Ensure left_indices are valid (>=0)
+            # This should also be guaranteed by interp_mask and clamping, but defensive check.
+            left_indices = torch.clamp(left_indices, 0, timestamps.numel() - 2)
+
+            t1 = timestamps[left_indices]
+            v1 = values[left_indices]
+            t2 = timestamps[right_indices]
+            v2 = values[right_indices]
+
+            dt = t2 - t1
+            dv = v2 - v1
+
+            # Initialize interpolated values for this segment with v1
+            # This correctly handles cases where dt == 0 (t1 == t2) by assigning v1.
+            interp_values_segment = v1.clone().to(torch.float32)
+
+            # Mask for points where linear interpolation is possible (dt > 0)
+            is_linear_interp_possible = dt > 0
+
+            if torch.any(is_linear_interp_possible):
+                # Calculate proportion only for points where dt > 0
+                # Ensure relevant_req_ts, t1, dt, v1, dv are indexed by is_linear_interp_possible for broadcasting
+                prop_ts = relevant_req_ts[is_linear_interp_possible]
+                prop_t1 = t1[is_linear_interp_possible]
+                prop_dt = dt[is_linear_interp_possible]
+                prop_v1 = v1[is_linear_interp_possible]
+                prop_dv = dv[is_linear_interp_possible]
+
+                proportion = (prop_ts - prop_t1) / prop_dt
+                interp_values_segment[is_linear_interp_possible] = (
+                    prop_v1 + proportion * prop_dv
+                ).to(torch.float32)  # Ensure result is float32
+
+            interpolated_results[interp_mask] = interp_values_segment
+
+        # Refinement for exact matches:
+        # This step ensures that if a required_timestamp exactly matches a keyframe timestamp,
+        # the exact keyframe value is used. This can sometimes be important due to floating point precision.
+        # Note: torch.searchsorted with side='left' gives the index `i` such that all e in a[:i] have e < v,
+        # and all e in a[i:] have e >= v.
+        # So if timestamps[indices_of_exact_matches] == required_timestamps, it's an exact match.
+
+        # Find potential indices for exact matches
+        indices_of_exact_matches = torch.searchsorted(
+            timestamps, required_timestamps, side="left"
+        )
+
+        # Clamp indices to be valid for `timestamps` tensor to avoid out-of-bounds errors
+        indices_of_exact_matches.clamp_(0, timestamps.numel() - 1)
+
+        # Create a mask for actual exact matches
+        # Need to check bounds for indices_of_exact_matches before indexing timestamps
+        # This check ensures we only use valid indices from searchsorted
+        # valid_indices_mask = indices_of_exact_matches < timestamps.numel() # Unused variable
+
+        # Further, ensure that timestamps at these clamped indices actually match
+        # This needs careful handling if required_timestamps can be outside the range of timestamps
+        # The extrapolation steps should have handled those already.
+        # We only care about exact matches within the original range of timestamps.
+
+        # Create a mask for valid exact matches
+        # exact_match_mask = torch.zeros_like( # Unused variable
+        #     required_timestamps, dtype=torch.bool
+        # )
+
+        # Check only if there are elements to avoid errors on empty tensors
+        if timestamps.numel() > 0 and required_timestamps.numel() > 0:
+            # Get timestamps that correspond to searchsorted indices
+            candidate_timestamps = timestamps[indices_of_exact_matches]
+            # Identify where these candidate timestamps are exactly equal to required_timestamps
+            actual_exact_matches = candidate_timestamps == required_timestamps
+            # Apply this mask to interpolated_results
+            if torch.any(actual_exact_matches):
+                interpolated_results[actual_exact_matches] = values[
+                    indices_of_exact_matches[actual_exact_matches]
+                ].to(torch.float32)
+
+        return interpolated_results.to(torch.float32)

--- a/tsercom/data/tensor/linear_interpolation_strategy_unittest.py
+++ b/tsercom/data/tensor/linear_interpolation_strategy_unittest.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+import torch  # Added torch
+import random # Moved from bottom
 
 # Assuming LinearInterpolationStrategy is in its own file now
 from tsercom.data.tensor.linear_interpolation_strategy import (
@@ -15,214 +17,366 @@ def linear_strategy() -> LinearInterpolationStrategy:
 
 def test_empty_keyframes(linear_strategy: LinearInterpolationStrategy):
     """Test interpolation with no keyframes."""
-    req_ts = [datetime(2023, 1, 1, 0, 0, 15, tzinfo=timezone.utc)]
-    assert linear_strategy.interpolate_series([], req_ts) == [None]
-    assert linear_strategy.interpolate_series([], []) == []
+    timestamps_tensor = torch.empty((0,), dtype=torch.float64)
+    values_tensor = torch.empty((0,), dtype=torch.float32)
+
+    # Test with one required timestamp
+    req_dt1 = datetime(2023, 1, 1, 0, 0, 15, tzinfo=timezone.utc)
+    req_ts_tensor1 = torch.tensor([req_dt1.timestamp()], dtype=torch.float64)
+
+    expected_result1 = torch.tensor([float("nan")], dtype=torch.float32)
+    actual_result1 = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor1
+    )
+
+    assert actual_result1.shape == expected_result1.shape
+    assert actual_result1.dtype == expected_result1.dtype
+    assert torch.isnan(
+        actual_result1
+    ).all(), "Expected NaN for non-empty required_timestamps with no keyframes"
+
+    # Test with empty required timestamps
+    req_ts_tensor2 = torch.empty((0,), dtype=torch.float64)
+    expected_result2 = torch.empty((0,), dtype=torch.float32)
+    actual_result2 = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor2
+    )
+    assert (
+        actual_result2.shape == expected_result2.shape
+    ), "Expected empty tensor for empty required_timestamps"
+    assert actual_result2.dtype == expected_result2.dtype
 
 
 def test_single_keyframe(linear_strategy: LinearInterpolationStrategy):
     """Test interpolation with a single keyframe. Should extrapolate its value."""
-    kf_ts = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    kf_dt = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
     kf_val = 10.0
-    keyframes = [(kf_ts, kf_val)]
 
-    req_ts_list = [
-        kf_ts - timedelta(seconds=5),
-        kf_ts,
-        kf_ts + timedelta(seconds=5),
+    timestamps_tensor = torch.tensor([kf_dt.timestamp()], dtype=torch.float64)
+    values_tensor = torch.tensor([kf_val], dtype=torch.float32)
+
+    req_dt_list = [
+        kf_dt - timedelta(seconds=5),
+        kf_dt,
+        kf_dt + timedelta(seconds=5),
     ]
-
-    expected_values = [kf_val, kf_val, kf_val]
-    assert (
-        linear_strategy.interpolate_series(keyframes, req_ts_list)
-        == expected_values
+    req_ts_tensor = torch.tensor(
+        [dt.timestamp() for dt in req_dt_list], dtype=torch.float64
     )
+
+    expected_result_tensor = torch.tensor(
+        [kf_val, kf_val, kf_val], dtype=torch.float32
+    )
+    actual_result_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
+
+    torch.testing.assert_close(actual_result_tensor, expected_result_tensor)
 
 
 def test_timestamp_before_first_keyframe(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test interpolation for a timestamp before the first keyframe. Should return first keyframe's value."""
-    kf1_ts = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
-    kf2_ts = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
-    keyframes = [(kf1_ts, 10.0), (kf2_ts, 20.0)]
+    kf1_dt = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    kf2_dt = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
 
-    req_ts = kf1_ts - timedelta(seconds=5)
-    assert linear_strategy.interpolate_series(keyframes, [req_ts]) == [10.0]
+    timestamps_tensor = torch.tensor(
+        [kf1_dt.timestamp(), kf2_dt.timestamp()], dtype=torch.float64
+    )
+    values_tensor = torch.tensor([10.0, 20.0], dtype=torch.float32)
+
+    req_dt = kf1_dt - timedelta(seconds=5)
+    req_ts_tensor = torch.tensor([req_dt.timestamp()], dtype=torch.float64)
+
+    expected_result_tensor = torch.tensor([10.0], dtype=torch.float32)
+    actual_result_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
+
+    torch.testing.assert_close(actual_result_tensor, expected_result_tensor)
 
 
 def test_timestamp_after_last_keyframe(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test interpolation for a timestamp after the last keyframe. Should return last keyframe's value."""
-    kf1_ts = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
-    kf2_ts = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
-    keyframes = [(kf1_ts, 10.0), (kf2_ts, 20.0)]
+    kf1_dt = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    kf2_dt = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
 
-    req_ts = kf2_ts + timedelta(seconds=5)
-    assert linear_strategy.interpolate_series(keyframes, [req_ts]) == [20.0]
+    timestamps_tensor = torch.tensor(
+        [kf1_dt.timestamp(), kf2_dt.timestamp()], dtype=torch.float64
+    )
+    values_tensor = torch.tensor([10.0, 20.0], dtype=torch.float32)
+
+    req_dt = kf2_dt + timedelta(seconds=5)
+    req_ts_tensor = torch.tensor([req_dt.timestamp()], dtype=torch.float64)
+
+    expected_result_tensor = torch.tensor([20.0], dtype=torch.float32)
+    actual_result_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
+
+    torch.testing.assert_close(actual_result_tensor, expected_result_tensor)
 
 
 def test_timestamp_exactly_on_keyframe(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test interpolation for a timestamp exactly matching a keyframe."""
-    kf1_ts = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
-    kf2_ts = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
-    kf3_ts = datetime(2023, 1, 1, 0, 0, 30, tzinfo=timezone.utc)
-    keyframes = [(kf1_ts, 10.0), (kf2_ts, 20.0), (kf3_ts, 30.0)]
+    kf1_dt = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    kf2_dt = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)
+    kf3_dt = datetime(2023, 1, 1, 0, 0, 30, tzinfo=timezone.utc)
 
-    assert linear_strategy.interpolate_series(keyframes, [kf1_ts]) == [10.0]
-    assert linear_strategy.interpolate_series(keyframes, [kf2_ts]) == [20.0]
-    assert linear_strategy.interpolate_series(keyframes, [kf3_ts]) == [30.0]
+    timestamps_tensor = torch.tensor(
+        [kf1_dt.timestamp(), kf2_dt.timestamp(), kf3_dt.timestamp()],
+        dtype=torch.float64,
+    )
+    values_tensor = torch.tensor([10.0, 20.0, 30.0], dtype=torch.float32)
+
+    # Test for kf1_dt
+    req_ts_tensor1 = torch.tensor([kf1_dt.timestamp()], dtype=torch.float64)
+    expected_result1 = torch.tensor([10.0], dtype=torch.float32)
+    actual_result1 = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor1
+    )
+    torch.testing.assert_close(actual_result1, expected_result1)
+
+    # Test for kf2_dt
+    req_ts_tensor2 = torch.tensor([kf2_dt.timestamp()], dtype=torch.float64)
+    expected_result2 = torch.tensor([20.0], dtype=torch.float32)
+    actual_result2 = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor2
+    )
+    torch.testing.assert_close(actual_result2, expected_result2)
+
+    # Test for kf3_dt
+    req_ts_tensor3 = torch.tensor([kf3_dt.timestamp()], dtype=torch.float64)
+    expected_result3 = torch.tensor([30.0], dtype=torch.float32)
+    actual_result3 = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor3
+    )
+    torch.testing.assert_close(actual_result3, expected_result3)
 
 
 def test_timestamp_between_keyframes(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test interpolation for a timestamp between two keyframes."""
-    kf1_ts = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)  # Value 10.0
-    kf2_ts = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)  # Value 20.0
-    keyframes = [(kf1_ts, 10.0), (kf2_ts, 20.0)]
+    kf1_dt = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)  # Value 10.0
+    kf2_dt = datetime(2023, 1, 1, 0, 0, 20, tzinfo=timezone.utc)  # Value 20.0
+
+    timestamps_tensor = torch.tensor(
+        [kf1_dt.timestamp(), kf2_dt.timestamp()], dtype=torch.float64
+    )
+    values_tensor = torch.tensor([10.0, 20.0], dtype=torch.float32)
 
     # Halfway between kf1 and kf2 (10s span, 5s in)
-    req_ts_halfway = kf1_ts + timedelta(seconds=5)
-    assert linear_strategy.interpolate_series(keyframes, [req_ts_halfway]) == [
-        pytest.approx(15.0)
-    ]
+    req_dt_halfway = kf1_dt + timedelta(seconds=5)
+    req_ts_halfway_tensor = torch.tensor(
+        [req_dt_halfway.timestamp()], dtype=torch.float64
+    )
+    expected_halfway_tensor = torch.tensor([15.0], dtype=torch.float32)
+    actual_halfway_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_halfway_tensor
+    )
+    torch.testing.assert_close(actual_halfway_tensor, expected_halfway_tensor)
 
     # Quarter way between kf1 and kf2 (2.5s in)
-    req_ts_quarter = kf1_ts + timedelta(seconds=2.5)
-    assert linear_strategy.interpolate_series(keyframes, [req_ts_quarter]) == [
-        pytest.approx(12.5)
-    ]
+    req_dt_quarter = kf1_dt + timedelta(seconds=2.5)
+    req_ts_quarter_tensor = torch.tensor(
+        [req_dt_quarter.timestamp()], dtype=torch.float64
+    )
+    expected_quarter_tensor = torch.tensor([12.5], dtype=torch.float32)
+    actual_quarter_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_quarter_tensor
+    )
+    torch.testing.assert_close(actual_quarter_tensor, expected_quarter_tensor)
 
 
 def test_multiple_required_timestamps(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test with a mix of required timestamps, covering various cases."""
-    kf_base = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    keyframes = [
-        (kf_base + timedelta(seconds=10), 10.0),  # KF1 @ 10s
-        (kf_base + timedelta(seconds=20), 20.0),  # KF2 @ 20s
-        (kf_base + timedelta(seconds=30), 15.0),  # KF3 @ 30s (value decreases)
-    ]
+    kf_base_dt = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
-    req_ts_list = [
-        kf_base + timedelta(seconds=5),  # Before KF1 -> 10.0
-        kf_base + timedelta(seconds=10),  # On KF1 -> 10.0
-        kf_base + timedelta(seconds=15),  # Between KF1 & KF2 (mid) -> 15.0
-        kf_base + timedelta(seconds=20),  # On KF2 -> 20.0
-        kf_base
+    keyframe_dts = [
+        kf_base_dt + timedelta(seconds=10),  # KF1 @ 10s
+        kf_base_dt + timedelta(seconds=20),  # KF2 @ 20s
+        kf_base_dt + timedelta(seconds=30),  # KF3 @ 30s (value decreases)
+    ]
+    keyframe_vals = [10.0, 20.0, 15.0]
+
+    timestamps_tensor = torch.tensor(
+        [dt.timestamp() for dt in keyframe_dts], dtype=torch.float64
+    )
+    values_tensor = torch.tensor(keyframe_vals, dtype=torch.float32)
+
+    req_dt_list = [
+        kf_base_dt + timedelta(seconds=5),  # Before KF1 -> 10.0
+        kf_base_dt + timedelta(seconds=10),  # On KF1 -> 10.0
+        kf_base_dt + timedelta(seconds=15),  # Between KF1 & KF2 (mid) -> 15.0
+        kf_base_dt + timedelta(seconds=20),  # On KF2 -> 20.0
+        kf_base_dt
         + timedelta(seconds=25),  # Between KF2 & KF3 (mid) -> (20+15)/2 = 17.5
-        kf_base + timedelta(seconds=30),  # On KF3 -> 15.0
-        kf_base + timedelta(seconds=35),  # After KF3 -> 15.0
+        kf_base_dt + timedelta(seconds=30),  # On KF3 -> 15.0
+        kf_base_dt + timedelta(seconds=35),  # After KF3 -> 15.0
     ]
+    req_ts_tensor = torch.tensor(
+        [dt.timestamp() for dt in req_dt_list], dtype=torch.float64
+    )
 
-    expected_values = [10.0, 10.0, 15.0, 20.0, 17.5, 15.0, 15.0]
+    expected_values_list = [10.0, 10.0, 15.0, 20.0, 17.5, 15.0, 15.0]
+    expected_result_tensor = torch.tensor(
+        expected_values_list, dtype=torch.float32
+    )
 
-    actual_values = linear_strategy.interpolate_series(keyframes, req_ts_list)
-    for actual, expected in zip(actual_values, expected_values):
-        assert actual == pytest.approx(expected)
+    actual_result_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
+    torch.testing.assert_close(actual_result_tensor, expected_result_tensor)
 
 
 def test_timestamps_with_microseconds(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test interpolation with timestamps having microseconds."""
-    kf1_ts = datetime(
+    kf1_dt = datetime(
         2023, 1, 1, 0, 0, 10, 100000, tzinfo=timezone.utc
     )  # 10.0 @ 10.1s
-    kf2_ts = datetime(
+    kf2_dt = datetime(
         2023, 1, 1, 0, 0, 10, 600000, tzinfo=timezone.utc
     )  # 20.0 @ 10.6s
-    # Span = 0.5s
-    keyframes = [(kf1_ts, 10.0), (kf2_ts, 20.0)]
+
+    timestamps_tensor = torch.tensor(
+        [kf1_dt.timestamp(), kf2_dt.timestamp()], dtype=torch.float64
+    )
+    values_tensor = torch.tensor([10.0, 20.0], dtype=torch.float32)
 
     # Midpoint: 10.1s + 0.25s = 10.35s
-    req_ts_mid = datetime(2023, 1, 1, 0, 0, 10, 350000, tzinfo=timezone.utc)
-    # Expected: 10.0 + (20.0-10.0) * (0.25s / 0.5s) = 10.0 + 10.0 * 0.5 = 15.0
-    assert linear_strategy.interpolate_series(keyframes, [req_ts_mid]) == [
-        pytest.approx(15.0)
-    ]
+    req_dt_mid = datetime(2023, 1, 1, 0, 0, 10, 350000, tzinfo=timezone.utc)
+    req_ts_mid_tensor = torch.tensor(
+        [req_dt_mid.timestamp()], dtype=torch.float64
+    )
+
+    # Expected: 10.0 + (20.0-10.0) * ( (10.35 - 10.1) / (10.6 - 10.1) )
+    # Expected: 10.0 + 10.0 * (0.25 / 0.5) = 10.0 + 10.0 * 0.5 = 15.0
+    expected_result_tensor = torch.tensor([15.0], dtype=torch.float32)
+    actual_result_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_mid_tensor
+    )
+
+    torch.testing.assert_close(actual_result_tensor, expected_result_tensor)
 
 
 def test_identical_timestamps_in_keyframes(
     linear_strategy: LinearInterpolationStrategy,
 ):
-    """Test behavior with identical timestamps in keyframes. bisect_left ensures stability."""
-    # If identical timestamps exist, bisect_left will place ts_req before the second identical one if ts_req matches.
-    # The logic should correctly pick one or interpolate based on distinct surrounding values if any.
-    # Current logic: if ts_req == key_times[idx], it uses key_values[idx].
-    # If key_times[idx-1] == key_times[idx], then (t2-t1) is 0.
-    # The code handles (t2-t1).total_seconds() == 0 by returning v1.
+    """Test behavior with identical timestamps in keyframes."""
+    kf_base_dt = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
-    kf_base = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    keyframes = [
-        (kf_base + timedelta(seconds=10), 10.0),
-        (kf_base + timedelta(seconds=20), 20.0),  # KF2a
-        (
-            kf_base + timedelta(seconds=20),
-            22.0,
-        ),  # KF2b (same timestamp, different value, later in list)
-        (kf_base + timedelta(seconds=30), 30.0),
+    keyframe_dts = [
+        kf_base_dt + timedelta(seconds=10),
+        kf_base_dt + timedelta(seconds=20),  # KF2a
+        kf_base_dt + timedelta(seconds=20),  # KF2b
+        kf_base_dt + timedelta(seconds=30),
     ]
+    keyframe_vals = [10.0, 20.0, 22.0, 30.0]
+
+    timestamps_tensor = torch.tensor(
+        [dt.timestamp() for dt in keyframe_dts], dtype=torch.float64
+    )
+    values_tensor = torch.tensor(keyframe_vals, dtype=torch.float32)
 
     # Request exactly on the duplicated timestamp
-    req_ts_duplicate = kf_base + timedelta(seconds=20)
-    # bisect_left will find the first occurrence (index 1, value 20.0)
-    assert linear_strategy.interpolate_series(
-        keyframes, [req_ts_duplicate]
-    ) == [20.0]
+    req_dt_duplicate = kf_base_dt + timedelta(seconds=20)
+    req_ts_duplicate_tensor = torch.tensor(
+        [req_dt_duplicate.timestamp()], dtype=torch.float64
+    )
+    expected_duplicate_tensor = torch.tensor(
+        [20.0], dtype=torch.float32
+    )  # Expects value of KF2a due to exact match logic
+    actual_duplicate_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_duplicate_tensor
+    )
+    torch.testing.assert_close(
+        actual_duplicate_tensor, expected_duplicate_tensor
+    )
 
     # Request between first KF and the duplicated timestamp (e.g., 15s)
-    req_ts_before_duplicate = kf_base + timedelta(
-        seconds=15
-    )  # Mid between 10s (10.0) and 20s (20.0)
-    assert linear_strategy.interpolate_series(
-        keyframes, [req_ts_before_duplicate]
-    ) == [pytest.approx(15.0)]
+    req_dt_before_duplicate = kf_base_dt + timedelta(seconds=15)
+    req_ts_before_duplicate_tensor = torch.tensor(
+        [req_dt_before_duplicate.timestamp()], dtype=torch.float64
+    )
+    expected_before_tensor = torch.tensor([15.0], dtype=torch.float32)
+    actual_before_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_before_duplicate_tensor
+    )
+    torch.testing.assert_close(actual_before_tensor, expected_before_tensor)
 
     # Request between the duplicated timestamp and the last one (e.g., 25s)
-    # This will interpolate between keyframes[2] (20s, 22.0) and keyframes[3] (30s, 30.0)
-    # Midpoint value = 22.0 + (30.0-22.0) * 0.5 = 22.0 + 8.0 * 0.5 = 22.0 + 4.0 = 26.0
-    req_ts_after_duplicate = kf_base + timedelta(seconds=25)
-    assert linear_strategy.interpolate_series(
-        keyframes, [req_ts_after_duplicate]
-    ) == [pytest.approx(26.0)]
+    req_dt_after_duplicate = kf_base_dt + timedelta(seconds=25)
+    req_ts_after_duplicate_tensor = torch.tensor(
+        [req_dt_after_duplicate.timestamp()], dtype=torch.float64
+    )
+    expected_after_tensor = torch.tensor(
+        [26.0], dtype=torch.float32
+    )  # Interpolates between (20s, 22.0) and (30s, 30.0)
+    actual_after_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_after_duplicate_tensor
+    )
+    torch.testing.assert_close(actual_after_tensor, expected_after_tensor)
 
 
-import random  # For random data generation
+# import random  # No longer here, moved to top
 
 
 def test_plateaus_in_keyframes(linear_strategy: LinearInterpolationStrategy):
     """Test interpolation over plateaus in keyframe values."""
-    kf_base = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    keyframes = [
-        (kf_base + timedelta(seconds=10), 10.0),  # Start
-        (kf_base + timedelta(seconds=20), 20.0),  # Rise
-        (kf_base + timedelta(seconds=30), 20.0),  # Plateau start
-        (kf_base + timedelta(seconds=40), 20.0),  # Plateau end
-        (kf_base + timedelta(seconds=50), 30.0),  # Rise again
-    ]
+    kf_base_dt = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
-    req_ts_list = [
-        kf_base + timedelta(seconds=15),  # Rising: 10 -> 20 (mid) = 15.0
-        kf_base + timedelta(seconds=25),  # On first plateau point = 20.0
-        kf_base
+    keyframe_dts = [
+        kf_base_dt + timedelta(seconds=10),  # Start
+        kf_base_dt + timedelta(seconds=20),  # Rise
+        kf_base_dt + timedelta(seconds=30),  # Plateau start
+        kf_base_dt + timedelta(seconds=40),  # Plateau end
+        kf_base_dt + timedelta(seconds=50),  # Rise again
+    ]
+    keyframe_vals = [10.0, 20.0, 20.0, 20.0, 30.0]
+
+    timestamps_tensor = torch.tensor(
+        [dt.timestamp() for dt in keyframe_dts], dtype=torch.float64
+    )
+    values_tensor = torch.tensor(keyframe_vals, dtype=torch.float32)
+
+    req_dt_list = [
+        kf_base_dt + timedelta(seconds=15),  # Rising: 10 -> 20 (mid) = 15.0
+        kf_base_dt
+        + timedelta(
+            seconds=25
+        ),  # On first plateau point (between 20s & 30s, val=20) -> 20.0
+        kf_base_dt
         + timedelta(seconds=30),  # Exactly on plateau start keyframe = 20.0
-        kf_base + timedelta(seconds=35),  # Mid-plateau = 20.0
-        kf_base
+        kf_base_dt + timedelta(seconds=35),  # Mid-plateau = 20.0
+        kf_base_dt
         + timedelta(seconds=40),  # Exactly on plateau end keyframe = 20.0
-        kf_base + timedelta(seconds=45),  # Rising: 20 -> 30 (mid) = 25.0
+        kf_base_dt + timedelta(seconds=45),  # Rising: 20 -> 30 (mid) = 25.0
     ]
+    req_ts_tensor = torch.tensor(
+        [dt.timestamp() for dt in req_dt_list], dtype=torch.float64
+    )
 
-    expected_values = [15.0, 20.0, 20.0, 20.0, 20.0, 25.0]
+    # Logic for req_ts_list[1] (25s):
+    # t1=(20s,20), t2=(30s,20). dt=10, dv=0. prop=(5/10)=0.5. interp = 20 + 0.5*0 = 20.
+    expected_values_list = [15.0, 20.0, 20.0, 20.0, 20.0, 25.0]
+    expected_result_tensor = torch.tensor(
+        expected_values_list, dtype=torch.float32
+    )
 
-    actual_values = linear_strategy.interpolate_series(keyframes, req_ts_list)
-    for actual, expected in zip(actual_values, expected_values):
-        assert actual == pytest.approx(expected)
+    actual_result_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
+    torch.testing.assert_close(actual_result_tensor, expected_result_tensor)
 
 
 def test_many_random_keyframes_and_timestamps(
@@ -234,80 +388,110 @@ def test_many_random_keyframes_and_timestamps(
 
     base_time_int = int(datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp())
 
-    keyframes = []
+    keyframe_dts = []
+    keyframe_vals = []
     current_ts_int = base_time_int
-    for i in range(num_keyframes):
-        current_ts_int += random.randint(
-            1, 10
-        )  # Ensure timestamps are increasing
+    for _ in range(num_keyframes):
+        current_ts_int += random.randint(1, 10)
         ts = datetime.fromtimestamp(current_ts_int, tz=timezone.utc)
         val = random.uniform(0.0, 100.0)
-        keyframes.append((ts, val))
+        keyframe_dts.append(ts)
+        keyframe_vals.append(val)
 
-    required_timestamps = []
-    # Ensure required timestamps span the keyframe range, plus some outside
-    min_kf_ts_int = keyframes[0][0].timestamp()
-    max_kf_ts_int = keyframes[-1][0].timestamp()
+    timestamps_tensor = torch.tensor(
+        [dt.timestamp() for dt in keyframe_dts], dtype=torch.float64
+    )
+    values_tensor = torch.tensor(keyframe_vals, dtype=torch.float32)
+
+    required_dt_list = []
+    min_kf_ts_float = keyframe_dts[0].timestamp()
+    max_kf_ts_float = keyframe_dts[-1].timestamp()
 
     for _ in range(num_req_timestamps):
-        # Generate timestamps before, within, and after the keyframe range
         rand_choice = random.random()
-        if rand_choice < 0.1:  # 10% before
-            req_ts_int = random.randint(
-                int(min_kf_ts_int) - 100, int(min_kf_ts_int) - 1
+        if rand_choice < 0.1:
+            req_ts_float = random.uniform(
+                min_kf_ts_float - 100, min_kf_ts_float - 1e-6
             )
-        elif rand_choice < 0.8:  # 70% within
-            req_ts_int = random.randint(int(min_kf_ts_int), int(max_kf_ts_int))
-        else:  # 20% after
-            req_ts_int = random.randint(
-                int(max_kf_ts_int) + 1, int(max_kf_ts_int) + 100
+        elif rand_choice < 0.8:
+            req_ts_float = random.uniform(min_kf_ts_float, max_kf_ts_float)
+        else:
+            req_ts_float = random.uniform(
+                max_kf_ts_float + 1e-6, max_kf_ts_float + 100
             )
-        required_timestamps.append(
-            datetime.fromtimestamp(req_ts_int, tz=timezone.utc)
+        required_dt_list.append(
+            datetime.fromtimestamp(req_ts_float, tz=timezone.utc)
         )
 
-    required_timestamps.sort()  # Strategy expects sorted required_timestamps for some internal logic/assumptions
-    # but the current interpolate_series processes one by one. Sorting is good practice.
-
-    interpolated_values = linear_strategy.interpolate_series(
-        keyframes, required_timestamps
+    required_dt_list.sort()
+    req_ts_tensor = torch.tensor(
+        [dt.timestamp() for dt in required_dt_list], dtype=torch.float64
     )
-    assert len(interpolated_values) == num_req_timestamps
 
-    # Basic validation: check a few points manually based on expected logic
+    interpolated_values_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
+    assert interpolated_values_tensor.numel() == num_req_timestamps
+    assert interpolated_values_tensor.dtype == torch.float32
+
+    # Basic validation: check a few points manually
     # 1. A timestamp before the first keyframe
-    ts_before = keyframes[0][0] - timedelta(seconds=1)
-    val_before = linear_strategy.interpolate_series(keyframes, [ts_before])[0]
-    assert val_before == pytest.approx(keyframes[0][1])
+    ts_before_dt = keyframe_dts[0] - timedelta(seconds=1)
+    req_before_tensor = torch.tensor(
+        [ts_before_dt.timestamp()], dtype=torch.float64
+    )
+    val_before_actual = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_before_tensor
+    )
+    torch.testing.assert_close(
+        val_before_actual,
+        torch.tensor([keyframe_vals[0]], dtype=torch.float32),
+    )
 
     # 2. A timestamp after the last keyframe
-    ts_after = keyframes[-1][0] + timedelta(seconds=1)
-    val_after = linear_strategy.interpolate_series(keyframes, [ts_after])[0]
-    assert val_after == pytest.approx(keyframes[-1][1])
+    ts_after_dt = keyframe_dts[-1] + timedelta(seconds=1)
+    req_after_tensor = torch.tensor(
+        [ts_after_dt.timestamp()], dtype=torch.float64
+    )
+    val_after_actual = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_after_tensor
+    )
+    torch.testing.assert_close(
+        val_after_actual,
+        torch.tensor([keyframe_vals[-1]], dtype=torch.float32),
+    )
 
     # 3. A timestamp exactly on a keyframe (e.g., middle keyframe)
     mid_kf_idx = num_keyframes // 2
-    ts_on = keyframes[mid_kf_idx][0]
-    val_on = linear_strategy.interpolate_series(keyframes, [ts_on])[0]
-    assert val_on == pytest.approx(keyframes[mid_kf_idx][1])
+    ts_on_dt = keyframe_dts[mid_kf_idx]
+    req_on_tensor = torch.tensor([ts_on_dt.timestamp()], dtype=torch.float64)
+    val_on_actual = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_on_tensor
+    )
+    torch.testing.assert_close(
+        val_on_actual,
+        torch.tensor([keyframe_vals[mid_kf_idx]], dtype=torch.float32),
+    )
 
     # 4. A timestamp between two keyframes
     if num_keyframes >= 2:
         idx1 = num_keyframes // 3
         idx2 = idx1 + 1
-        if idx2 < num_keyframes:  # Ensure idx2 is a valid index
-            ts1, v1 = keyframes[idx1]
-            ts2, v2 = keyframes[idx2]
-            if (
-                ts1 != ts2
-            ):  # Avoid division by zero if timestamps happen to be identical
-                ts_between = ts1 + (ts2 - ts1) / 2
-                val_between_expected = v1 + (v2 - v1) * 0.5
+        if idx2 < num_keyframes:
+            ts1_dt, v1_val = keyframe_dts[idx1], keyframe_vals[idx1]
+            ts2_dt, v2_val = keyframe_dts[idx2], keyframe_vals[idx2]
+            if ts1_dt != ts2_dt:
+                ts_between_dt = ts1_dt + (ts2_dt - ts1_dt) / 2
+                val_between_expected = v1_val + (v2_val - v1_val) * 0.5
+                req_between_tensor = torch.tensor(
+                    [ts_between_dt.timestamp()], dtype=torch.float64
+                )
                 val_between_actual = linear_strategy.interpolate_series(
-                    keyframes, [ts_between]
-                )[0]
-                assert val_between_actual == pytest.approx(
-                    val_between_expected
+                    timestamps_tensor, values_tensor, req_between_tensor
+                )
+                torch.testing.assert_close(
+                    val_between_actual,
+                    torch.tensor([val_between_expected], dtype=torch.float32),
                 )
 
 
@@ -315,46 +499,66 @@ def test_required_timestamps_very_close_to_keyframes(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test with required timestamps epsilon-close to keyframe timestamps."""
-    kf_base = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    kf_base_dt = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     epsilon_td = timedelta(microseconds=1)
 
-    keyframes = [
-        (kf_base + timedelta(seconds=10), 10.0),
-        (kf_base + timedelta(seconds=20), 20.0),
+    keyframe_dts = [
+        kf_base_dt + timedelta(seconds=10),
+        kf_base_dt + timedelta(seconds=20),
     ]
+    keyframe_vals = [10.0, 20.0]
 
-    kf1_ts, kf1_val = keyframes[0]
-    kf2_ts, kf2_val = keyframes[1]
+    timestamps_tensor = torch.tensor(
+        [dt.timestamp() for dt in keyframe_dts], dtype=torch.float64
+    )
+    values_tensor = torch.tensor(keyframe_vals, dtype=torch.float32)
 
-    req_ts_list = [
-        kf1_ts - epsilon_td,  # Just before KF1
-        kf1_ts + epsilon_td,  # Just after KF1
-        kf2_ts - epsilon_td,  # Just before KF2
-        kf2_ts + epsilon_td,  # Just after KF2
+    kf1_dt, kf1_val = keyframe_dts[0], keyframe_vals[0]
+    kf2_dt, kf2_val = keyframe_dts[1], keyframe_vals[1]
+
+    req_dt_list = [
+        kf1_dt - epsilon_td,  # Just before KF1
+        kf1_dt + epsilon_td,  # Just after KF1
+        kf2_dt - epsilon_td,  # Just before KF2
+        kf2_dt + epsilon_td,  # Just after KF2
     ]
+    req_ts_tensor = torch.tensor(
+        [dt.timestamp() for dt in req_dt_list], dtype=torch.float64
+    )
 
-    results = linear_strategy.interpolate_series(keyframes, req_ts_list)
+    results_tensor = linear_strategy.interpolate_series(
+        timestamps_tensor, values_tensor, req_ts_tensor
+    )
 
     # Just before KF1 should still be KF1's value (extrapolation rule)
-    assert results[0] == pytest.approx(kf1_val)
+    torch.testing.assert_close(
+        results_tensor[0], torch.tensor(kf1_val, dtype=torch.float32)
+    )
 
     # Just after KF1 should be very close to KF1, interpolated towards KF2
-    # expected = v1 + (v2-v1) * (eps_seconds / total_duration_seconds)
-    duration_seconds = (kf2_ts - kf1_ts).total_seconds()
+    duration_seconds = (kf2_dt - kf1_dt).total_seconds()
     eps_seconds = epsilon_td.total_seconds()
-    expected_after_kf1 = kf1_val + (kf2_val - kf1_val) * (
+    expected_after_kf1_val = kf1_val + (kf2_val - kf1_val) * (
         eps_seconds / duration_seconds
     )
-    assert results[1] == pytest.approx(expected_after_kf1)
+    torch.testing.assert_close(
+        results_tensor[1],
+        torch.tensor(expected_after_kf1_val, dtype=torch.float32),
+    )
 
     # Just before KF2 should be very close to KF2, interpolated from KF1
-    expected_before_kf2 = kf1_val + (kf2_val - kf1_val) * (
+    expected_before_kf2_val = kf1_val + (kf2_val - kf1_val) * (
         (duration_seconds - eps_seconds) / duration_seconds
     )
-    assert results[2] == pytest.approx(expected_before_kf2)
+    torch.testing.assert_close(
+        results_tensor[2],
+        torch.tensor(expected_before_kf2_val, dtype=torch.float32),
+    )
 
     # Just after KF2 should be KF2's value (extrapolation rule)
-    assert results[3] == pytest.approx(kf2_val)
+    torch.testing.assert_close(
+        results_tensor[3], torch.tensor(kf2_val, dtype=torch.float32)
+    )
 
 
 # Reviewing test_identical_timestamps_in_keyframes - it seems robust.
@@ -367,36 +571,47 @@ def test_interpolation_over_zero_duration_segment(
     linear_strategy: LinearInterpolationStrategy,
 ):
     """Test when two keyframes have identical timestamps (zero duration segment)."""
-    kf_ts = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
-    keyframes = [
-        (kf_ts, 10.0),
-        (kf_ts, 20.0),  # Same timestamp, different value
-    ]
-    # If required_ts is kf_ts, bisect_left gives index 0. Result: 10.0
-    assert linear_strategy.interpolate_series(keyframes, [kf_ts]) == [10.0]
+    kf_dt = datetime(2023, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
 
-    # If we had more keyframes, e.g.:
-    kf_ts_next = kf_ts + timedelta(seconds=1)
-    keyframes_extended = [
-        (kf_ts, 10.0),  # idx 0
-        (kf_ts, 20.0),  # idx 1
-        (kf_ts_next, 30.0),  # idx 2
-    ]
-    # Request at kf_ts: interpolate_series uses keyframes[0] = (kf_ts, 10.0) -> 10.0
-    assert linear_strategy.interpolate_series(keyframes_extended, [kf_ts]) == [
-        10.0
-    ]
+    # Case 1: Two keyframes with identical timestamps
+    timestamps1 = torch.tensor(
+        [kf_dt.timestamp(), kf_dt.timestamp()], dtype=torch.float64
+    )
+    values1 = torch.tensor([10.0, 20.0], dtype=torch.float32)
+    req_ts1 = torch.tensor([kf_dt.timestamp()], dtype=torch.float64)
+    expected1 = torch.tensor(
+        [10.0], dtype=torch.float32
+    )  # Exact match logic picks the first one
+    actual1 = linear_strategy.interpolate_series(timestamps1, values1, req_ts1)
+    torch.testing.assert_close(actual1, expected1)
 
-    # Request slightly after kf_ts, e.g., kf_ts + 0.5s
-    # This should interpolate between keyframes[1]=(kf_ts, 20.0) and keyframes[2]=(kf_ts_next, 30.0)
-    # because keyframes[0] is before ts_req, and keyframes[1] is <= ts_req.
-    # bisect_left for (kf_ts + 0.5s) in [kf_ts, kf_ts, kf_ts_next] would be index 2.
-    # So, t1=keyframes[1], t2=keyframes[2].
-    # t1 = (kf_ts, 20.0), t2 = (kf_ts_next, 30.0)
+    # Case 2: Extended keyframes
+    kf_dt_next = kf_dt + timedelta(seconds=1)
+    timestamps2 = torch.tensor(
+        [kf_dt.timestamp(), kf_dt.timestamp(), kf_dt_next.timestamp()],
+        dtype=torch.float64,
+    )
+    values2 = torch.tensor([10.0, 20.0, 30.0], dtype=torch.float32)
+
+    # Request at kf_dt
+    req_ts2_exact = torch.tensor([kf_dt.timestamp()], dtype=torch.float64)
+    expected2_exact = torch.tensor(
+        [10.0], dtype=torch.float32
+    )  # Exact match logic picks the first one
+    actual2_exact = linear_strategy.interpolate_series(
+        timestamps2, values2, req_ts2_exact
+    )
+    torch.testing.assert_close(actual2_exact, expected2_exact)
+
+    # Request slightly after kf_dt (e.g., kf_dt + 0.5s)
+    req_dt_half_after = kf_dt + timedelta(microseconds=500000)
+    req_ts2_half_after = torch.tensor(
+        [req_dt_half_after.timestamp()], dtype=torch.float64
+    )
+    # Interpolates between (kf_dt, 20.0) and (kf_dt_next, 30.0)
     # Expected: 20.0 + (30.0-20.0) * 0.5 = 25.0
-    req_ts_half_second_after = kf_ts + timedelta(
-        microseconds=500000
-    )  # 0.5 seconds
-    assert linear_strategy.interpolate_series(
-        keyframes_extended, [req_ts_half_second_after]
-    ) == [pytest.approx(25.0)]
+    expected2_half_after = torch.tensor([25.0], dtype=torch.float32)
+    actual2_half_after = linear_strategy.interpolate_series(
+        timestamps2, values2, req_ts2_half_after
+    )
+    torch.testing.assert_close(actual2_half_after, expected2_half_after)

--- a/tsercom/data/tensor/smoothed_tensor_demuxer_unittest.py
+++ b/tsercom/data/tensor/smoothed_tensor_demuxer_unittest.py
@@ -14,8 +14,10 @@ import pytest_asyncio
 from pytest_mock import MockerFixture
 
 from tsercom.data.tensor.smoothed_tensor_demuxer import SmoothedTensorDemuxer
-from tsercom.data.tensor.smoothing_strategy import SmoothingStrategy
-from tsercom.data.tensor.linear_interpolation_strategy import LinearInterpolationStrategy
+from tsercom.data.tensor.linear_interpolation_strategy import (
+    LinearInterpolationStrategy,
+)
+
 
 class TestClientInterface(abc.ABC):
     @abc.abstractmethod
@@ -23,6 +25,7 @@ class TestClientInterface(abc.ABC):
         self, tensor_name: str, data: torch.Tensor, timestamp: real_datetime
     ) -> None:
         pass
+
 
 class MockClient(TestClientInterface):
     def __init__(self) -> None:
@@ -46,13 +49,16 @@ class MockClient(TestClientInterface):
         self.last_pushed_tensor = None
         self.last_pushed_timestamp = None
 
+
 @pytest.fixture
 def mock_client() -> MockClient:
     return MockClient()
 
+
 @pytest.fixture
 def linear_strategy() -> LinearInterpolationStrategy:
     return LinearInterpolationStrategy()
+
 
 @pytest_asyncio.fixture
 async def demuxer(
@@ -76,6 +82,7 @@ async def demuxer(
     ):
         await demuxer_instance.stop()
 
+
 @pytest.mark.asyncio
 async def test_initialization(
     mock_client: MockClient, linear_strategy: LinearInterpolationStrategy
@@ -94,49 +101,114 @@ async def test_initialization(
     assert demuxer_instance.get_tensor_shape() == tensor_shape
     assert demuxer_instance._output_interval_seconds == output_interval
 
+
 @pytest.mark.asyncio
-async def test_on_update_received_adds_keyframes(
+async def test_on_update_received_adds_keyframes(  # Renamed from test_on_update_received_adds_and_sorts_keyframes to match original
     demuxer: SmoothedTensorDemuxer,
 ) -> None:
     ts1 = real_datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ts1_float = ts1.timestamp()
     ts2 = real_datetime(2023, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    ts2_float = ts2.timestamp()
     index0 = (0,)
-    await demuxer.on_update_received(index0, 10.0, ts2)
-    await demuxer.on_update_received(index0, 5.0, ts1)
+
+    await demuxer.on_update_received(index0, 10.0, ts2)  # ts2, value 10.0
+    await demuxer.on_update_received(
+        index0, 5.0, ts1
+    )  # ts1, value 5.0 (should be sorted before ts2)
+
     async with demuxer._keyframes_lock:
-        keyframes_idx0 = demuxer._SmoothedTensorDemuxer__per_index_keyframes[  # type: ignore [attr-defined]
-            index0
-        ]
-    assert len(keyframes_idx0) == 2
-    assert keyframes_idx0[0] == (ts1, 5.0)
+        keyframes_tuple = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get(index0)  # type: ignore [attr-defined]
+
+    assert keyframes_tuple is not None, "Keyframes for index0 should exist"
+    timestamps_tensor, values_tensor = keyframes_tuple
+
+    assert isinstance(timestamps_tensor, torch.Tensor)
+    assert isinstance(values_tensor, torch.Tensor)
+
+    assert timestamps_tensor.dtype == torch.float64
+    assert values_tensor.dtype == torch.float32
+
+    assert timestamps_tensor.numel() == 2, "Should have 2 keyframes"
+    assert values_tensor.numel() == 2, "Should have 2 keyframes"
+
+    # Check sorting and values
+    # Expected order: (ts1, 5.0), (ts2, 10.0)
+    assert timestamps_tensor[0].item() == pytest.approx(ts1_float)
+    assert values_tensor[0].item() == pytest.approx(5.0)
+
+    assert timestamps_tensor[1].item() == pytest.approx(ts2_float)
+    assert values_tensor[1].item() == pytest.approx(10.0)
+
 
 @pytest.mark.asyncio
 async def test_on_update_received_respects_history_limit(
     linear_strategy: LinearInterpolationStrategy, mock_client: MockClient
 ) -> None:
     history_limit = 3
-    demuxer_limited_fixture = (
-        SmoothedTensorDemuxer(
-            tensor_name="limited_tensor",
-            tensor_shape=(1,),
-            output_client=mock_client,
-            smoothing_strategy=linear_strategy,
-            output_interval_seconds=0.1,
-            max_keyframe_history_per_index=history_limit,
-        )
+    demuxer_limited = SmoothedTensorDemuxer(  # Renamed fixture variable
+        tensor_name="limited_tensor",
+        tensor_shape=(1,),
+        output_client=mock_client,
+        smoothing_strategy=linear_strategy,
+        output_interval_seconds=0.1,
+        max_keyframe_history_per_index=history_limit,
     )
     index = (0,)
     base_ts = real_datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    for i in range(history_limit + 2):
+    total_updates = history_limit + 2  # 5 updates
+
+    timestamps_added = []
+    values_added = []
+
+    for i in range(total_updates):  # Adds values 0.0, 1.0, 2.0, 3.0, 4.0
         ts = base_ts + timedelta(seconds=i)
-        await demuxer_limited_fixture.on_update_received(index, float(i), ts)
-    async with (
-        demuxer_limited_fixture._keyframes_lock
-    ):
-        keyframes = demuxer_limited_fixture._SmoothedTensorDemuxer__per_index_keyframes[index]  # type: ignore [attr-defined]
-    assert len(keyframes) == history_limit
-    assert keyframes[0][1] == float(history_limit + 2 - history_limit)
-    assert keyframes[-1][1] == float(history_limit + 2 - 1)
+        val = float(i)
+        timestamps_added.append(ts.timestamp())
+        values_added.append(val)
+        await demuxer_limited.on_update_received(index, val, ts)
+
+    async with demuxer_limited._keyframes_lock:
+        keyframes_tuple = demuxer_limited._SmoothedTensorDemuxer__per_index_keyframes.get(index)  # type: ignore [attr-defined]
+
+    assert keyframes_tuple is not None, "Keyframes for index should exist"
+    timestamps_tensor, values_tensor = keyframes_tuple
+
+    assert isinstance(timestamps_tensor, torch.Tensor)
+    assert isinstance(values_tensor, torch.Tensor)
+
+    assert (
+        timestamps_tensor.numel() == history_limit
+    ), f"Expected {history_limit} timestamps after pruning"
+    assert (
+        values_tensor.numel() == history_limit
+    ), f"Expected {history_limit} values after pruning"
+
+    # After adding 0,1,2,3,4 (total 5) and pruning to 3, we expect to keep 2,3,4
+    expected_first_kept_value = values_added[
+        total_updates - history_limit
+    ]  # values_added[5-3] = values_added[2] = 2.0
+    expected_last_kept_value = values_added[-1]  # values_added[4] = 4.0
+
+    expected_first_kept_ts = timestamps_added[total_updates - history_limit]
+    expected_last_kept_ts = timestamps_added[-1]
+
+    assert values_tensor[0].item() == pytest.approx(expected_first_kept_value)
+    assert timestamps_tensor[0].item() == pytest.approx(expected_first_kept_ts)
+
+    assert values_tensor[-1].item() == pytest.approx(expected_last_kept_value)
+    assert timestamps_tensor[-1].item() == pytest.approx(expected_last_kept_ts)
+
+    # Check all kept values
+    expected_kept_values = values_added[total_updates - history_limit :]
+    for i in range(history_limit):
+        assert values_tensor[i].item() == pytest.approx(
+            expected_kept_values[i]
+        )
+        assert timestamps_tensor[i].item() == pytest.approx(
+            timestamps_added[total_updates - history_limit + i]
+        )
+
 
 @pytest.mark.asyncio
 async def test_interpolation_worker_simple_case(
@@ -156,24 +228,28 @@ async def test_interpolation_worker_simple_case(
     mock_client.clear_pushes()
 
     current_time_for_mock = [ts1]
+
     class MockedDateTime(real_datetime):
         @classmethod
         def now(cls, tz=None):
             dt_to_return = current_time_for_mock[0]
             return dt_to_return.replace(tzinfo=tz) if tz else dt_to_return
+
     MockedDateTime.timedelta = timedelta
     MockedDateTime.timezone = timezone
 
-    mocker.patch("tsercom.data.tensor.smoothed_tensor_demuxer.datetime", MockedDateTime)
+    mocker.patch(
+        "tsercom.data.tensor.smoothed_tensor_demuxer.datetime", MockedDateTime
+    )
 
     await demuxer.start()
 
     # Worker's internal sleep will be approx. output_interval_seconds (0.05s)
     # Cycle 1
     current_time_for_mock[0] = ts1
-    await asyncio.sleep(0.001) # Let worker calculate first sleep
+    await asyncio.sleep(0.001)  # Let worker calculate first sleep
     current_time_for_mock[0] = ts1 + timedelta(seconds=0.05)
-    await asyncio.sleep(0.05 + 0.02) # Worker sleep (0.05) + buffer
+    await asyncio.sleep(0.05 + 0.02)  # Worker sleep (0.05) + buffer
 
     # Cycle 2
     current_time_for_mock[0] = ts1 + timedelta(seconds=0.10)
@@ -196,15 +272,20 @@ async def test_interpolation_worker_simple_case(
         expected_push_times = [
             ts1 + timedelta(seconds=0.05),
             ts1 + timedelta(seconds=0.10),
-            ts1 + timedelta(seconds=0.15)
+            ts1 + timedelta(seconds=0.15),
         ]
-        if not any(abs((push_ts - ept).total_seconds()) < 0.01 for ept in expected_push_times):
+        if not any(
+            abs((push_ts - ept).total_seconds()) < 0.01
+            for ept in expected_push_times
+        ):
             continue
 
         if ts1 < push_ts < ts2:
             val0 = data_tensor[0].item()
             val1 = data_tensor[1].item()
-            time_ratio = (push_ts - ts1).total_seconds() / (ts2 - ts1).total_seconds()
+            time_ratio = (push_ts - ts1).total_seconds() / (
+                ts2 - ts1
+            ).total_seconds()
             expected_val_0 = 10.0 + (20.0 - 10.0) * time_ratio
             expected_val_1 = 100.0 + (200.0 - 100.0) * time_ratio
 
@@ -216,15 +297,21 @@ async def test_interpolation_worker_simple_case(
         found_relevant_push
     ), f"No relevant interpolated tensor found between keyframes. Pushed timestamps: {pushed_timestamps}. ts1={ts1}, ts2={ts2}"
 
+
 @pytest.mark.asyncio
 async def test_critical_cascading_interpolation_scenario(
     mock_client: MockClient, linear_strategy: LinearInterpolationStrategy
 ) -> None:
     demuxer_cascade = SmoothedTensorDemuxer(
-        tensor_name="cascade_tensor", tensor_shape=(4,), output_client=mock_client,
-        smoothing_strategy=linear_strategy, output_interval_seconds=0.05,
-        max_keyframe_history_per_index=10, align_output_timestamps=False,
-        name="CascadeDemuxer", fill_value=float("nan"),
+        tensor_name="cascade_tensor",
+        tensor_shape=(4,),
+        output_client=mock_client,
+        smoothing_strategy=linear_strategy,
+        output_interval_seconds=0.05,
+        max_keyframe_history_per_index=10,
+        align_output_timestamps=False,
+        name="CascadeDemuxer",
+        fill_value=float("nan"),
     )
     time_A = real_datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     time_B = time_A + timedelta(seconds=2)
@@ -248,18 +335,31 @@ async def test_critical_cascading_interpolation_scenario(
     output_tensor_manual = torch.full(
         demuxer_cascade.get_tensor_shape(), float("nan"), dtype=torch.float32
     )
+    # Convert target datetime to float timestamp for tensor operations
+    time_interp_target_float = time_interp_target.timestamp()
+    required_ts_tensor = torch.tensor(
+        [time_interp_target_float], dtype=torch.float64
+    )
+
     async with demuxer_cascade._keyframes_lock:
         for i in range(demuxer_cascade.get_tensor_shape()[0]):
             idx = (i,)
-            keyframes_for_index = demuxer_cascade._SmoothedTensorDemuxer__per_index_keyframes.get(  # type: ignore [attr-defined]
-                idx, []
-            )
-            if keyframes_for_index:
-                interpolated_values = linear_strategy.interpolate_series(
-                    keyframes_for_index, [time_interp_target]
+            keyframes_tuple = demuxer_cascade._SmoothedTensorDemuxer__per_index_keyframes.get(idx)  # type: ignore [attr-defined]
+
+            if keyframes_tuple and keyframes_tuple[0].numel() > 0:
+                timestamps_tensor, values_tensor = keyframes_tuple
+                # Ensure tensors are on the same device if necessary, though typically not an issue for CPU tests
+                interpolated_values_tensor = (
+                    linear_strategy.interpolate_series(
+                        timestamps_tensor, values_tensor, required_ts_tensor
+                    )
                 )
-                if interpolated_values and interpolated_values[0] is not None:
-                    output_tensor_manual[idx] = float(interpolated_values[0])
+                if interpolated_values_tensor.numel() > 0 and not torch.isnan(
+                    interpolated_values_tensor[0]
+                ):
+                    output_tensor_manual[idx] = interpolated_values_tensor[
+                        0
+                    ].item()
 
     expected_val_0 = 62.5
     expected_val_1 = 95.0
@@ -269,6 +369,7 @@ async def test_critical_cascading_interpolation_scenario(
     assert output_tensor_manual[1].item() == pytest.approx(expected_val_1)
     assert output_tensor_manual[2].item() == pytest.approx(expected_val_2)
     assert output_tensor_manual[3].item() == pytest.approx(expected_val_3)
+
 
 @pytest.mark.asyncio
 async def test_start_stop_worker(
@@ -285,68 +386,110 @@ async def test_start_stop_worker(
         or demuxer._interpolation_worker_task.done()
     )
 
+
 @pytest.mark.asyncio
 async def test_process_external_update_decomposes_tensor(
     demuxer: SmoothedTensorDemuxer,
 ) -> None:
     ts = real_datetime(2023, 1, 1, 0, 0, 5, tzinfo=timezone.utc)
-    full_tensor_data = torch.tensor([55.0, 66.0], dtype=torch.float32)
+    ts_float = ts.timestamp()
+    full_tensor_data = torch.tensor(
+        [55.0, 66.0], dtype=torch.float32
+    )  # Demuxer shape is (2,)
 
     await demuxer.process_external_update(
         demuxer.tensor_name, full_tensor_data, ts
     )
 
     async with demuxer._keyframes_lock:
-        keyframes_idx0 = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get((0,))  # type: ignore [attr-defined]
-        keyframes_idx1 = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get((1,))  # type: ignore [attr-defined]
+        keyframes_idx0_tuple = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get((0,))  # type: ignore [attr-defined]
+        keyframes_idx1_tuple = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get((1,))  # type: ignore [attr-defined]
 
-    assert keyframes_idx0 is not None and len(keyframes_idx0) == 1
-    assert keyframes_idx0[0] == (ts, 55.0)
-    assert keyframes_idx1 is not None and len(keyframes_idx1) == 1
-    assert keyframes_idx1[0] == (ts, 66.0)
+    assert (
+        keyframes_idx0_tuple is not None
+    ), "Keyframes for index (0,) should exist"
+    timestamps0_tensor, values0_tensor = keyframes_idx0_tuple
+    assert timestamps0_tensor.numel() == 1
+    assert values0_tensor.numel() == 1
+    assert timestamps0_tensor[0].item() == pytest.approx(ts_float)
+    assert values0_tensor[0].item() == pytest.approx(55.0)
+    assert timestamps0_tensor.dtype == torch.float64
+    assert values0_tensor.dtype == torch.float32
+
+    assert (
+        keyframes_idx1_tuple is not None
+    ), "Keyframes for index (1,) should exist"
+    timestamps1_tensor, values1_tensor = keyframes_idx1_tuple
+    assert timestamps1_tensor.numel() == 1
+    assert values1_tensor.numel() == 1
+    assert timestamps1_tensor[0].item() == pytest.approx(ts_float)
+    assert values1_tensor[0].item() == pytest.approx(66.0)
+    assert timestamps1_tensor.dtype == torch.float64
+    assert values1_tensor.dtype == torch.float32
+
 
 @pytest.mark.asyncio
 async def test_empty_keyframes_output_fill_value(
-    demuxer: SmoothedTensorDemuxer, mock_client: MockClient, mocker: MockerFixture
+    demuxer: SmoothedTensorDemuxer,
+    mock_client: MockClient,
+    mocker: MockerFixture,
 ) -> None:
     demuxer._output_interval_seconds = 0.05
 
-    fixed_keyframe_time = real_datetime(2023,1,1,12,0,0, tzinfo=timezone.utc)
+    fixed_keyframe_time = real_datetime(
+        2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc
+    )
     await demuxer.on_update_received((0,), 10.0, fixed_keyframe_time)
 
     current_time_for_mock = [fixed_keyframe_time]
+
     class MockedDateTimeEmpty(real_datetime):
         @classmethod
         def now(cls, tz=None):
             dt = current_time_for_mock[0]
             return dt.replace(tzinfo=tz) if tz else dt
+
     MockedDateTimeEmpty.timedelta = timedelta
     MockedDateTimeEmpty.timezone = timezone
 
-    mocker.patch("tsercom.data.tensor.smoothed_tensor_demuxer.datetime", MockedDateTimeEmpty)
+    mocker.patch(
+        "tsercom.data.tensor.smoothed_tensor_demuxer.datetime",
+        MockedDateTimeEmpty,
+    )
 
     await demuxer.start()
 
     # Worker's internal sleep approx 0.05s
     current_time_for_mock[0] = fixed_keyframe_time
     await asyncio.sleep(0.001)
-    current_time_for_mock[0] = fixed_keyframe_time + timedelta(seconds=demuxer._output_interval_seconds * 0.5) # Advance to mid-sleep
-    await asyncio.sleep(0.05 + 0.02) # Let worker wake up and push
+    current_time_for_mock[0] = fixed_keyframe_time + timedelta(
+        seconds=demuxer._output_interval_seconds * 0.5
+    )  # Advance to mid-sleep
+    await asyncio.sleep(0.05 + 0.02)  # Let worker wake up and push
 
-    current_time_for_mock[0] = fixed_keyframe_time + timedelta(seconds=demuxer._output_interval_seconds * 1.5)
+    current_time_for_mock[0] = fixed_keyframe_time + timedelta(
+        seconds=demuxer._output_interval_seconds * 1.5
+    )
     await asyncio.sleep(0.05 + 0.02)
 
     await demuxer.stop()
 
     pushed_timestamps = [p[2] for p in mock_client.pushes]
-    assert len(mock_client.pushes) > 0, f"Worker should have pushed tensors. Pushed: {pushed_timestamps}"
+    assert (
+        len(mock_client.pushes) > 0
+    ), f"Worker should have pushed tensors. Pushed: {pushed_timestamps}"
 
     last_tensor = mock_client.last_pushed_tensor
     assert last_tensor is not None
     assert last_tensor.shape == demuxer.get_tensor_shape()
 
-    assert not torch.isnan(last_tensor[0]).item(), "Index (0) should have a real value (extrapolated)"
-    assert torch.isnan(last_tensor[1]).item(), "Index (1) should be NaN (fill_value)"
+    assert not torch.isnan(
+        last_tensor[0]
+    ).item(), "Index (0) should have a real value (extrapolated)"
+    assert torch.isnan(
+        last_tensor[1]
+    ).item(), "Index (1) should be NaN (fill_value)"
+
 
 @pytest.mark.asyncio
 async def test_align_output_timestamps_true(
@@ -355,7 +498,9 @@ async def test_align_output_timestamps_true(
     mocker: MockerFixture,
 ):
     output_interval = 1.0
-    start_time = real_datetime(2023, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc)
+    start_time = real_datetime(
+        2023, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc
+    )
 
     demuxer_aligned = SmoothedTensorDemuxer(
         tensor_name="aligned_tensor",
@@ -364,29 +509,36 @@ async def test_align_output_timestamps_true(
         smoothing_strategy=linear_strategy,
         output_interval_seconds=output_interval,
         align_output_timestamps=True,
-        name="AlignedDemuxer"
+        name="AlignedDemuxer",
     )
 
     kf_ts = start_time - timedelta(seconds=0.2)
     await demuxer_aligned.on_update_received((0,), 10.0, kf_ts)
 
     current_time_for_mock = [start_time]
+
     class MockedDateTimeAlign(real_datetime):
         @classmethod
         def now(cls, tz=None):
             dt = current_time_for_mock[0]
             return dt.replace(tzinfo=tz) if tz is not None else dt
+
     MockedDateTimeAlign.timedelta = timedelta
     MockedDateTimeAlign.timezone = timezone
 
-    mocker.patch("tsercom.data.tensor.smoothed_tensor_demuxer.datetime", MockedDateTimeAlign)
+    mocker.patch(
+        "tsercom.data.tensor.smoothed_tensor_demuxer.datetime",
+        MockedDateTimeAlign,
+    )
 
     # Calculation of expected push times based on worker logic:
     # 1. Worker starts, current_loop_start_time is mocked to 'start_time' (...0.500Z)
     # 2. _last_pushed_timestamp = _get_next_aligned_timestamp(start_time). For 0.5s and interval 1.0s, this is ...1.000Z.
     # 3. next_output_timestamp (before re-align) = ...1.000Z + 1.0s = ...2.000Z.
     # 4. next_output_timestamp (after re-align in worker) = _get_next_aligned_timestamp(...2.000Z) which is ...3.000Z.
-    expected_first_push_ts = real_datetime(2023, 1, 1, 0, 0, 3, 0, tzinfo=timezone.utc)
+    expected_first_push_ts = real_datetime(
+        2023, 1, 1, 0, 0, 3, 0, tzinfo=timezone.utc
+    )
     # Worker's first sleep duration: (expected_first_push_ts - start_time).total_seconds() = 2.5s
 
     # For second push:
@@ -394,20 +546,26 @@ async def test_align_output_timestamps_true(
     # current_loop_start_time for second push is expected_first_push_ts (...3.000Z)
     # next_output_timestamp (before re-align) = ...3.000Z + 1.0s = ...4.000Z
     # next_output_timestamp (after re-align) = _get_next_aligned_timestamp(...4.000Z) = ...5.000Z
-    expected_second_push_ts = real_datetime(2023, 1, 1, 0, 0, 5, 0, tzinfo=timezone.utc)
+    expected_second_push_ts = real_datetime(
+        2023, 1, 1, 0, 0, 5, 0, tzinfo=timezone.utc
+    )
     # Worker's second sleep duration: (expected_second_push_ts - expected_first_push_ts).total_seconds() = 2.0s
 
     await demuxer_aligned.start()
 
     # First push sequence
     current_time_for_mock[0] = start_time
-    await asyncio.sleep(0.01) # Let worker calculate first sleep (2.5s)
+    await asyncio.sleep(0.01)  # Let worker calculate first sleep (2.5s)
     current_time_for_mock[0] = expected_first_push_ts
-    await asyncio.sleep(2.5 + 0.02) # Wait for worker's first sleep to end and push
+    await asyncio.sleep(
+        2.5 + 0.02
+    )  # Wait for worker's first sleep to end and push
 
     # Second push sequence
     current_time_for_mock[0] = expected_second_push_ts
-    await asyncio.sleep(2.0 + 0.02) # Wait for worker's second sleep to end and push
+    await asyncio.sleep(
+        2.0 + 0.02
+    )  # Wait for worker's second sleep to end and push
 
     await demuxer_aligned.stop()
 
@@ -425,9 +583,12 @@ async def test_align_output_timestamps_true(
         assert second_push_ts == expected_second_push_ts
         assert second_push_ts.timestamp() % output_interval == 0.0
 
+
 @pytest.mark.asyncio
 async def test_small_max_keyframe_history(
-    mock_client: MockClient, linear_strategy: LinearInterpolationStrategy, mocker: MockerFixture
+    mock_client: MockClient,
+    linear_strategy: LinearInterpolationStrategy,
+    mocker: MockerFixture,
 ):
     history_limit = 1
     demuxer_small_hist = SmoothedTensorDemuxer(
@@ -436,7 +597,7 @@ async def test_small_max_keyframe_history(
         output_client=mock_client,
         smoothing_strategy=linear_strategy,
         output_interval_seconds=0.05,
-        max_keyframe_history_per_index=history_limit
+        max_keyframe_history_per_index=history_limit,
     )
 
     ts1 = real_datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
@@ -445,17 +606,24 @@ async def test_small_max_keyframe_history(
 
     await demuxer_small_hist.on_update_received((0,), 10.0, ts1)
     await demuxer_small_hist.on_update_received((0,), 20.0, ts2)
-    await demuxer_small_hist.on_update_received((0,), 30.0, ts3) # ts3 is the only one remaining
+    await demuxer_small_hist.on_update_received(
+        (0,), 30.0, ts3
+    )  # ts3 is the only one remaining
 
     current_time_for_mock = [ts3]
+
     class MockedDateTimeSmallHist(real_datetime):
         @classmethod
         def now(cls, tz=None):
             dt = current_time_for_mock[0]
             return dt.replace(tzinfo=tz) if tz else dt
+
     MockedDateTimeSmallHist.timedelta = timedelta
     MockedDateTimeSmallHist.timezone = timezone
-    mocker.patch("tsercom.data.tensor.smoothed_tensor_demuxer.datetime", MockedDateTimeSmallHist)
+    mocker.patch(
+        "tsercom.data.tensor.smoothed_tensor_demuxer.datetime",
+        MockedDateTimeSmallHist,
+    )
 
     mock_client.clear_pushes()
     await demuxer_small_hist.start()
@@ -463,13 +631,16 @@ async def test_small_max_keyframe_history(
     # Worker's first current_loop_start_time = ts3
     # First next_output_timestamp = ts3 + 0.05s
     # Worker sleeps for 0.05s
-    current_time_for_mock[0] = ts3 + timedelta(seconds=demuxer_small_hist._output_interval_seconds)
+    current_time_for_mock[0] = ts3 + timedelta(
+        seconds=demuxer_small_hist._output_interval_seconds
+    )
     await asyncio.sleep(0.05 + 0.02)
 
     await demuxer_small_hist.stop()
     assert len(mock_client.pushes) > 0
     for _, tensor_data, _ in mock_client.pushes:
         assert tensor_data[0].item() == pytest.approx(30.0)
+
 
 @pytest.mark.asyncio
 async def test_2d_tensor_shape(
@@ -482,7 +653,7 @@ async def test_2d_tensor_shape(
         tensor_shape=(2, 2),
         output_client=mock_client,
         smoothing_strategy=linear_strategy,
-        output_interval_seconds=0.05
+        output_interval_seconds=0.05,
     )
 
     ts1 = real_datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
@@ -496,22 +667,29 @@ async def test_2d_tensor_shape(
     await demuxer_2d.on_update_received((0, 0), 15.0, ts2)
 
     current_time_for_mock_2d = [ts1]
+
     class MockedDateTime2D(real_datetime):
         @classmethod
         def now(cls, tz=None):
             dt = current_time_for_mock_2d[0]
             return dt.replace(tzinfo=tz) if tz is not None else dt
+
     MockedDateTime2D.timedelta = timedelta
     MockedDateTime2D.timezone = timezone
 
-    mocker.patch("tsercom.data.tensor.smoothed_tensor_demuxer.datetime", MockedDateTime2D)
+    mocker.patch(
+        "tsercom.data.tensor.smoothed_tensor_demuxer.datetime",
+        MockedDateTime2D,
+    )
 
     await demuxer_2d.start()
 
     # Worker's first current_loop_start_time = ts1
     # Worker's first next_output_timestamp = ts1 + 0.05s
     # Worker's first sleep_duration = 0.05s
-    expected_push_time = ts1 + timedelta(seconds=demuxer_2d._output_interval_seconds)
+    expected_push_time = ts1 + timedelta(
+        seconds=demuxer_2d._output_interval_seconds
+    )
 
     current_time_for_mock_2d[0] = ts1
     await asyncio.sleep(0.01)
@@ -526,20 +704,28 @@ async def test_2d_tensor_shape(
 
     found_interp_frame = False
     for _, tensor_data, push_ts in mock_client.pushes:
-        if abs((push_ts - expected_push_time).total_seconds()) < demuxer_2d._output_interval_seconds * 0.5:
-            assert tensor_data.shape == (2,2)
-            time_ratio = (push_ts - ts1).total_seconds() / (ts2 - ts1).total_seconds()
+        if (
+            abs((push_ts - expected_push_time).total_seconds())
+            < demuxer_2d._output_interval_seconds * 0.5
+        ):
+            assert tensor_data.shape == (2, 2)
+            time_ratio = (push_ts - ts1).total_seconds() / (
+                ts2 - ts1
+            ).total_seconds()
             time_ratio = max(0.0, min(1.0, time_ratio))
             expected_00 = 10.0 + (15.0 - 10.0) * time_ratio
-            assert tensor_data[0,0].item() == pytest.approx(expected_00, abs=1e-5)
-            assert tensor_data[0,1].item() == pytest.approx(20.0)
-            assert tensor_data[1,0].item() == pytest.approx(30.0)
-            assert tensor_data[1,1].item() == pytest.approx(40.0)
+            assert tensor_data[0, 0].item() == pytest.approx(
+                expected_00, abs=1e-5
+            )
+            assert tensor_data[0, 1].item() == pytest.approx(20.0)
+            assert tensor_data[1, 0].item() == pytest.approx(30.0)
+            assert tensor_data[1, 1].item() == pytest.approx(40.0)
             found_interp_frame = True
             break
     assert (
         found_interp_frame
     ), f"No suitable interpolated frame found. Expected around {expected_push_time}. Pushed: {pushed_timestamps}"
+
 
 @pytest.mark.asyncio
 async def test_significantly_out_of_order_updates(
@@ -556,14 +742,53 @@ async def test_significantly_out_of_order_updates(
     await demuxer.on_update_received((0,), 1.0, old_ts)
 
     async with demuxer._keyframes_lock:
-        keyframes_idx0 = demuxer._SmoothedTensorDemuxer__per_index_keyframes[(0,)] # type: ignore [attr-defined]
-        assert keyframes_idx0[0] == (old_ts, 1.0)
+        keyframes_tuple1 = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get((0,))  # type: ignore [attr-defined]
+    assert keyframes_tuple1 is not None
+    timestamps_tensor1, values_tensor1 = keyframes_tuple1
+    assert timestamps_tensor1[0].item() == pytest.approx(old_ts.timestamp())
+    assert values_tensor1[0].item() == pytest.approx(1.0)
+    assert timestamps_tensor1.numel() == 6  # 5 initial + 1 old_ts
 
-    for i in range(10):
+    # Max history for the default demuxer is 10
+    # Currently 6 items. Add 10 more. Total 16. Should keep latest 10.
+    # Items before these adds, sorted by time:
+    # (1s,1), (20s,20), (21s,21), (22s,22), (23s,23), (24s,24)
+    # Adding (30s,30) ... (39s,39)
+    # After all adds and pruning, the 10 latest should be:
+    # (30s,30), (31s,31), ..., (39s,39)
+    # The original test asserted the first item is (30s, 30.0), which means
+    # (1s,1) and (20s,20)...(24s,24) are all pruned.
+    # Let's trace:
+    # Start with 6 items: (1s,1), (20s,20), (21s,21), (22s,22), (23s,23), (24s,24)
+    # Add (30s,30) -> 7 items. No prune.
+    # Add (31s,31) -> 8 items. No prune.
+    # Add (32s,32) -> 9 items. No prune.
+    # Add (33s,33) -> 10 items. No prune.
+    # Add (34s,34) -> 11 items. Prune 1. (1s,1) is pruned. First is (20s,20).
+    # Add (35s,35) -> 11 items. Prune 1. (20s,20) is pruned. First is (21s,21).
+    # Add (36s,36) -> 11 items. Prune 1. (21s,21) is pruned. First is (22s,22).
+    # Add (37s,37) -> 11 items. Prune 1. (22s,22) is pruned. First is (23s,23).
+    # Add (38s,38) -> 11 items. Prune 1. (23s,23) is pruned. First is (24s,24).
+    # Add (39s,39) -> 11 items. Prune 1. (24s,24) is pruned. First is (30s,30).
+    # This matches the original test's expectation.
+
+    for i in range(10):  # Adds (30s,30) ... (39s,39)
         await demuxer.on_update_received(
             (0,), float(i + 30), base_ts + timedelta(seconds=i + 30)
         )
 
     async with demuxer._keyframes_lock:
-        keyframes_idx0 = demuxer._SmoothedTensorDemuxer__per_index_keyframes[(0,)] # type: ignore [attr-defined]
-        assert keyframes_idx0[0] == (base_ts + timedelta(seconds=30), 30.0)
+        keyframes_tuple2 = demuxer._SmoothedTensorDemuxer__per_index_keyframes.get((0,))  # type: ignore [attr-defined]
+
+    assert keyframes_tuple2 is not None
+    timestamps_tensor2, values_tensor2 = keyframes_tuple2
+
+    assert (
+        timestamps_tensor2.numel() == demuxer._max_keyframe_history_per_index
+    )  # Should be 10
+    expected_first_ts = base_ts + timedelta(seconds=30)
+    expected_first_val = 30.0
+    assert timestamps_tensor2[0].item() == pytest.approx(
+        expected_first_ts.timestamp()
+    )
+    assert values_tensor2[0].item() == pytest.approx(expected_first_val)

--- a/tsercom/data/tensor/smoothing_strategy.py
+++ b/tsercom/data/tensor/smoothing_strategy.py
@@ -1,10 +1,5 @@
 import abc
-from datetime import datetime
-from typing import (
-    List,
-    Tuple,
-    Union,
-)  # Added Union based on LinearInterpolationStrategy return type
+import torch
 
 
 class SmoothingStrategy(abc.ABC):
@@ -15,18 +10,21 @@ class SmoothingStrategy(abc.ABC):
     @abc.abstractmethod
     def interpolate_series(
         self,
-        keyframes: List[Tuple[datetime, float]],
-        required_timestamps: List[datetime],
-    ) -> List[
-        Union[float, None]
-    ]:  # Matched return type with concrete implementation
+        timestamps: torch.Tensor,
+        values: torch.Tensor,
+        required_timestamps: torch.Tensor,
+    ) -> torch.Tensor:
         """
         Interpolates values for a series of required timestamps based on keyframes.
 
         Args:
-            keyframes: A time-sorted list of (timestamp, value) tuples.
-            required_timestamps: A list of datetime objects for which values are needed.
+            timestamps: torch.Tensor: A 1D tensor of Unix timestamps (float64), sorted.
+            values: torch.Tensor: A 1D tensor of corresponding values (float32).
+            required_timestamps: torch.Tensor: A 1D tensor of Unix timestamps (float64)
+                               for which values are needed.
 
         Returns:
-            A list of interpolated values (float) or None.
+            torch.Tensor: A 1D tensor of interpolated values (float32), same size as
+                          `required_timestamps`. Contains `float('nan')` where
+                          interpolation is not possible.
         """


### PR DESCRIPTION
This commit refactors `SmoothedTensorDemuxer` and its associated components to use `torch.Tensor` for storing and processing time series keyframe data, replacing the previous Python list-based approach. This change is aimed at improving performance.

Key changes include:

1.  **`SmoothedTensorDemuxer` Internal Storage:**
    *   The `__per_index_keyframes` attribute now stores data as a
        `Dict[Tuple[int, ...], Tuple[torch.Tensor, torch.Tensor]]`.
    *   The first tensor in the tuple holds timestamps (as `float64` Unix
        timestamps), and the second holds corresponding values (as `float32`).
    *   The `on_update_received` method was updated to use `torch.searchsorted`
        for finding insertion points and `torch.cat` for inserting new
        keyframes into these sorted tensors. Pruning logic was also adapted
        for tensor operations.
    *   The `_interpolation_worker` method was updated to retrieve and pass
        these tensors to the smoothing strategy.

2.  **`SmoothingStrategy` Interface and `LinearInterpolationStrategy`:**
    *   The `SmoothingStrategy.interpolate_series` abstract method signature
        was changed to accept `timestamps: torch.Tensor`, `values: torch.Tensor`,
        and `required_timestamps: torch.Tensor`, returning a `torch.Tensor`.
    *   `LinearInterpolationStrategy.interpolate_series` was rewritten to
        perform linear interpolation using vectorized PyTorch tensor operations,
        handling edge cases (empty/single keyframes) and extrapolation.
        A dtype mismatch during calculation was fixed by ensuring the result
        is cast to `float32`.

3.  **Testing:**
    *   Unit tests for `SmoothedTensorDemuxer`
        (`smoothed_tensor_demuxer_unittest.py`) were updated to reflect
        the internal data structure changes and ensure continued correctness
        of insertion, pruning, and overall output.
    *   Unit tests for `LinearInterpolationStrategy`
        (`linear_interpolation_strategy_unittest.py`) were updated to use
        tensor inputs and validate tensor outputs.
    *   I executed focused tests and two full test suite runs, confirming no regressions were introduced.

4.  **Static Analysis:**
    *   I ran `black`, `ruff --fix`, and `mypy` on the modified files,
        and applied their suggested fixes. I also ran `Pylint` and noted its feedback.

The `TensorDemuxer` class was reviewed but not refactored, as its internal list usage for `ExplicitUpdate` does not directly correspond to the per-index time series storage that was the target of this refactoring.