### PR TITLE
I've added an E2E test for gRPC transport and refactored runtime access.

### DIFF
--- a/tsercom/api/local_process/runtime_command_bridge.py
+++ b/tsercom/api/local_process/runtime_command_bridge.py
@@ -64,8 +64,11 @@ class RuntimeCommandBridge:
                 except concurrent.futures.TimeoutError:
                     # Log or handle timeout if needed
                     pass  # Or raise an error, log, etc.
-
             self.__state.set(None)
+
+    def get_runtime(self) -> Optional[Runtime]:
+        """Returns the underlying Runtime instance, if set."""
+        return self.__runtime
 
     def start(self) -> None:
         """Requests the Runtime to start.

--- a/tsercom/api/local_process/runtime_command_bridge.py
+++ b/tsercom/api/local_process/runtime_command_bridge.py
@@ -66,7 +66,7 @@ class RuntimeCommandBridge:
                     pass  # Or raise an error, log, etc.
             self.__state.set(None)
 
-    def get_runtime(self) -> Optional[Runtime]:
+    def _get_runtime_for_test(self) -> Optional[Runtime]:
         """Returns the underlying Runtime instance, if set."""
         return self.__runtime
 

--- a/tsercom/api/local_process/runtime_wrapper.py
+++ b/tsercom/api/local_process/runtime_wrapper.py
@@ -114,10 +114,10 @@ class RuntimeWrapper(
         """Provides the remote data aggregator."""
         return self._get_remote_data_aggregator()
 
-    def get_actual_runtime(
+    def _get_runtime_for_test(
         self,
-    ) -> Optional[Runtime]:  # Changed to non-generic Runtime
-        """Provides access to the actual underlying Runtime instance."""
+    ) -> Optional[Runtime]:  # Renamed method
+        """Provides access to the actual underlying Runtime instance (for testing)."""
         if self.__bridge:
-            return self.__bridge.get_runtime()
+            return self.__bridge._get_runtime_for_test()
         return None

--- a/tsercom/api/local_process/runtime_wrapper.py
+++ b/tsercom/api/local_process/runtime_wrapper.py
@@ -14,6 +14,7 @@ from tsercom.data.exposed_data import ExposedData
 from tsercom.data.remote_data_aggregator import RemoteDataAggregator
 from tsercom.data.remote_data_aggregator_impl import RemoteDataAggregatorImpl
 from tsercom.data.remote_data_reader import RemoteDataReader
+from tsercom.runtime.runtime import Runtime  # Added import
 from tsercom.threading.aio.async_poller import AsyncPoller
 
 DataTypeT = TypeVar("DataTypeT", bound=ExposedData)
@@ -112,3 +113,11 @@ class RuntimeWrapper(
     ) -> RemoteDataAggregator[AnnotatedInstance[DataTypeT]]:
         """Provides the remote data aggregator."""
         return self._get_remote_data_aggregator()
+
+    def get_actual_runtime(
+        self,
+    ) -> Optional[Runtime]:  # Changed to non-generic Runtime
+        """Provides access to the actual underlying Runtime instance."""
+        if self.__bridge:
+            return self.__bridge.get_runtime()
+        return None

--- a/tsercom/full_app_e2etest.py
+++ b/tsercom/full_app_e2etest.py
@@ -567,7 +567,9 @@ async def test_full_app_with_grpc_transport(clear_loop_fixture, caplog):
     server_runtime_handle.start()
     client_runtime_handle.start()
 
-    client_runtime_maybe = cast(RuntimeWrapper[Any, Any], client_runtime_handle)._get_runtime_for_test()
+    client_runtime_maybe = cast(
+        RuntimeWrapper[Any, Any], client_runtime_handle
+    )._get_runtime_for_test()
     assert (
         client_runtime_maybe is not None
     ), "Failed to get actual client runtime from handle"

--- a/tsercom/test/proto/generated/v1_73/e2e_test_service_pb2_grpc.py
+++ b/tsercom/test/proto/generated/v1_73/e2e_test_service_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import e2e_test_service_pb2 as e2e__test__service__pb2
+from . import e2e_test_service_pb2 as e2e__test__service__pb2
 
 GRPC_GENERATED_VERSION = "1.73.0"
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
This change introduces a new end-to-end test, `test_full_app_with_grpc_transport`, to `tsercom/full_app_e2etest.py`. This test validates the full application flow using a real gRPC communication channel for a test-specific service defined in `tsercom/test/proto/e2e_test_service.proto`.

Key changes include:

1.  **E2eTestServicer Implementation**: A new gRPC servicer, `E2eTestServicer`, was added to `full_app_e2etest.py` to handle RPCs for the `E2ETestService`.
2.  **Server-Side Runtime Update**: `GenericServerRuntime` in `full_app_e2etest.py` was enhanced to host gRPC services. It now initializes a `GrpcServicePublisher` and adds the `E2eTestServicer` to its gRPC server instance. `GenericServerRuntimeInitializer` was updated to support this.
3.  **Client-Side Runtime Update**: `GenericClientRuntime` in `full_app_e2etest.py` was updated to include a method `create_e2e_test_stub(target_address)`. This allows it to create a gRPC stub for the `E2ETestService`. `GenericClientRuntimeInitializer` was updated to facilitate this.
4.  **New E2E Test**: `test_full_app_with_grpc_transport` was added.
    - It sets up client and server runtimes using `RuntimeManager`.
    - The server-side initializer (`GenericServerRuntimeInitializer`) is configured with a `fake_service_port`, which results in its internal `ServiceConnector` using a `FakeMdnsListener` to simulate discovery of the client runtime.
    - The `E2ETestService` is hosted by `GenericServerRuntime` on a dedicated port.
    - The test directly creates a gRPC channel from the client runtime to the server runtime's `E2ETestService` port to perform an `Echo` RPC call.
    - Data transfer and correct reception are asserted.
5.  **Refactoring for Testability**:
    - To enable the test to access the `GenericClientRuntime` instance and call `create_e2e_test_stub`, `RuntimeCommandBridge` and `RuntimeWrapper` (in `tsercom/api/local_process/`) were refactored to add `get_actual_runtime()` methods.
    - Corrected gRPC channel creation in `GenericClientRuntime` to use the `async connect` method from `GrpcChannelFactory`.
6.  **Static Analysis**: All changes passed Black, Ruff, MyPy, and Pylint checks.

The new E2E test `test_full_app_with_grpc_transport` and the existing test `test_anomoly_service` in `tsercom/full_app_e2etest.py` pass consistently.

Note on Full Test Suite:
The full `pytest --timeout=120` test suite currently has 5 known pre-existing failures in other modules (unrelated to these changes):
- tsercom/tensor/serialization/serializable_tensor_unittest.py::test_dense_tensor_serialization_deserialization[shape0-dtype4]
- tsercom/timesync/client/client_synchronized_clock_unittest.py::test_bad_client_impl_instantiation
- tsercom/timesync/common/synchronized_clock_unittest.py::test_bad_clock_no_sync_instantiation
- tsercom/timesync/common/synchronized_clock_unittest.py::test_bad_clock_no_desync_instantiation
- tsercom/timesync/common/synchronized_clock_unittest.py::test_bad_clock_no_methods_instantiation These failures were present before these changes were applied.