### PR TITLE
Fix: Refactor DelegatingMultiprocessQueueFactory for fork safety

### DIFF
--- a/execute_file_rewrite.py
+++ b/execute_file_rewrite.py
@@ -1,0 +1,61 @@
+import re
+
+original_content = """""" # This will be replaced by the actual file content from the previous tool run
+
+# Remove the start and end markers from read_files
+start_marker_str = "[start of tsercom/threading/multiprocess/delegating_multiprocess_queue_factory_unittest.py]"
+end_marker_str = "[end of tsercom/threading/multiprocess/delegating_multiprocess_queue_factory_unittest.py]"
+
+# Clean the start
+if original_content.startswith(start_marker_str):
+    original_content = original_content[len(start_marker_str):].lstrip()
+
+# Clean any occurrences of the end marker (especially if duplicated)
+lines = original_content.splitlines()
+cleaned_lines = [line for line in lines if line.strip() != end_marker_str] # Use strip() for robustness
+python_code_content = "\n".join(cleaned_lines)
+
+new_worker_code = """
+def _minimal_producer_worker(
+    tmp_queue: Any, # Should be torch.multiprocessing.Queue
+    tensor_to_send: TensorType,
+    result_q: Any # Standard ctx.Queue for status
+):
+    try:
+        print(f"[MinimalProducerMODIFIED] Original tensor: {tensor_to_send}")
+
+        # Ensure contiguity and then share memory
+        if not tensor_to_send.is_contiguous():
+            print("[MinimalProducerMODIFIED] Tensor not contiguous. Making it contiguous.")
+            tensor_to_send = tensor_to_send.contiguous()
+
+        print("[MinimalProducerMODIFIED] Calling share_memory_() on tensor.")
+        tensor_to_send.share_memory_() # Explicitly share memory
+        print(f"[MinimalProducerMODIFIED] Putting tensor after share_memory_(): {tensor_to_send}")
+        tmp_queue.put(tensor_to_send)
+        print(f"[MinimalProducerMODIFIED] Tensor put successfully.")
+        result_q.put("producer_success")
+    except Exception as e:
+        import traceback
+        tb_str = traceback.format_exc()
+        print(f"[MinimalProducerMODIFIED] EXCEPTION: {e}\\n{tb_str}") # Escaped newline for Python string
+        result_q.put(f"producer_exception: {type(e).__name__}: {e}")
+"""
+
+# Replace the old _minimal_producer_worker with the new one.
+start_marker_func = "def _minimal_producer_worker("
+# This regex looks for the function definition until the next 'def ' at the same indentation or end of string.
+pattern = re.compile(r"^(def _minimal_producer_worker\(.*?\):(?:\n(?:[ \t].*)*\n*))+", re.MULTILINE)
+
+match = pattern.search(python_code_content)
+if match:
+    # Ensure new_worker_code ends with a newline to separate it from the following code
+    updated_content = pattern.sub(new_worker_code.strip() + "\n\n", python_code_content, 1)
+    print("SUCCESS: _minimal_producer_worker replaced.")
+else:
+    print("ERROR: Could not find _minimal_producer_worker to replace. Original content (or part of it) will be written if this is an error.")
+    updated_content = "ERROR: Replacement failed in Python script. Original content might be lost or corrupted."
+
+
+with open("tsercom/threading/multiprocess/delegating_multiprocess_queue_factory_unittest.py", "w") as f:
+    f.write(updated_content)

--- a/tsercom/api/split_process/split_runtime_factory_factory.py
+++ b/tsercom/api/split_process/split_runtime_factory_factory.py
@@ -32,7 +32,7 @@ from tsercom.threading.multiprocess.multiprocess_queue_factory import (
 # but SplitFactoryFactory doesn't choose it directly anymore)
 from tsercom.threading.multiprocess.delegating_multiprocess_queue_factory import (
     DelegatingMultiprocessQueueFactory,
-    is_torch_available,
+    _TORCH_AVAILABLE,  # Changed from is_torch_available
 )
 from tsercom.threading.multiprocess.multiprocess_queue_sink import (
     MultiprocessQueueSink,
@@ -89,7 +89,7 @@ class SplitRuntimeFactoryFactory(RuntimeFactoryFactory[DataTypeT, EventTypeT]):
         # If available, Delegating factory will decide specific queue type (torch/default)
         # based on the first item sent.
         # If not available, always use default queues.
-        if is_torch_available():
+        if _TORCH_AVAILABLE:  # Changed from is_torch_available()
             event_queue_factory = DelegatingMultiprocessQueueFactory[
                 EventInstance[EventTypeT]
             ]()

--- a/tsercom/runtime_e2etest.py
+++ b/tsercom/runtime_e2etest.py
@@ -1968,10 +1968,10 @@ def test_out_of_process_delegating_pytorch_unavailable(clear_loop_fixture):
     # Need to import patch from unittest.mock
     # from unittest.mock import patch # This should be at the top of the file ideally.
 
-    # Path to IS_TORCH_AVAILABLE as used by SplitRuntimeFactoryFactory
-    path_to_mock = "tsercom.api.split_process.split_runtime_factory_factory.is_torch_available"
+    # Path to _TORCH_AVAILABLE as used by SplitRuntimeFactoryFactory
+    path_to_mock = "tsercom.api.split_process.split_runtime_factory_factory._TORCH_AVAILABLE"
 
-    with patch(path_to_mock, return_value=False):
+    with patch(path_to_mock, False): # Patching a boolean constant
         # Call the original __check_initialization test logic
         # __check_initialization itself uses FakeRuntimeInitializer (non-tensor)
         # If this test passes, it means DefaultMPQueue was used and worked.

--- a/tsercom/threading/multiprocess/delegating_multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/delegating_multiprocess_queue_factory.py
@@ -1,24 +1,22 @@
-"""Defines a factory for queues that dynamically delegate queue creation.
+"""Defines a factory for queues that eagerly creates multiple queue types
+and dynamically delegates to one based on the first item sent.
 
-The DelegatingMultiprocessQueueFactory conditionally uses torch.multiprocessing.Manager
-if PyTorch is available, or standard multiprocessing.Manager otherwise.
-All dynamically determined queues (for both tensor and non-tensor data paths)
-are created using this manager's Queue() method. This ensures the queue proxies
-are compatible with the manager's shared dictionary for inter-process sharing.
+The DelegatingMultiprocessQueueFactory eagerly creates two sets of queues:
+1. One pair using DefaultMultiprocessQueueFactory.
+2. A second pair using TorchMultiprocessQueueFactory (if PyTorch is available).
 
-The DelegatingQueueSink inspects the first item. The 'queue_type' stored in the
-shared dictionary ('torch_manager_queue' or 'default_manager_queue') indicates
-the nature of the data path, even though the underlying queue mechanism is
-unified to a manager-created queue.
+The DelegatingMultiprocessQueueSink inspects the first item sent.
+If it's a torch.Tensor, it sends a coordination message on the default queue
+and then uses the torch queue for all subsequent items. Otherwise, it sends a
+different coordination message on the default queue and uses the default queue
+for all items.
+
+The DelegatingMultiprocessQueueSource listens on the default queue for the
+coordination message and then switches to the appropriate underlying queue.
 """
 
-import multiprocessing
-from multiprocessing.managers import DictProxy, SyncManager
-import queue
-import threading
-import time
-from typing import TypeVar, Generic, Optional, Tuple
-from types import ModuleType
+import queue  # For queue.Empty
+from typing import TypeVar, Generic, Optional, Tuple, Literal
 
 from tsercom.threading.multiprocess.default_multiprocess_queue_factory import (
     DefaultMultiprocessQueueFactory,
@@ -36,156 +34,128 @@ from tsercom.threading.multiprocess.multiprocess_queue_factory import (
     MultiprocessQueueFactory,
 )
 
-_torch_mp_module: Optional[ModuleType] = None
-_torch_available: bool
+_TORCH_AVAILABLE: bool
+_torch_tensor_type: Optional[type] = None
 
 try:
     import torch
-    import torch.multiprocessing as torch_mp_imported
 
-    _torch_mp_module = torch_mp_imported
-    _torch_available = True  # pylint: disable=invalid-name
+    # Keep torch_mp_imported if needed by TorchMultiprocessQueueFactory,
+    # but it's not directly used in *this* file's logic anymore for manager decisions.
+    # import torch.multiprocessing as torch_mp_imported # Not directly used here anymore for manager
+    _TORCH_AVAILABLE = True
+    _torch_tensor_type = torch.Tensor
 except ImportError:
-    _torch_available = False  # pylint: disable=invalid-name
+    _TORCH_AVAILABLE = False
 
 
-QueueItemType = TypeVar("QueueItemType")  # pylint: disable=invalid-name
+_QueueItemType = TypeVar("_QueueItemType")
+
+# Coordination messages
+USE_TORCH_QUEUE_MSG = "USE_TORCH"
+USE_DEFAULT_QUEUE_MSG = "USE_DEFAULT"
+SelectedQueueType = Literal["torch", "default"]
 
 
-def is_torch_available() -> bool:
-    """Checks if PyTorch is available in the current environment."""
-    return _torch_available
-
-
-INITIALIZED_KEY = "initialized"
-REAL_QUEUE_SOURCE_REF_KEY = "real_queue_source_ref"
-REAL_QUEUE_SINK_REF_KEY = "real_queue_sink_ref"
-
-
-# pylint: disable=W0231
-class DelegatingMultiprocessQueueSink(MultiprocessQueueSink[QueueItemType]):
+# pylint: disable=W0231 # __init__ not called for base class if not appropriate
+class DelegatingMultiprocessQueueSink(MultiprocessQueueSink[_QueueItemType]):
     """
-    A multiprocessing queue sink that determines the underlying queue type
-    (Torch or default) based on the first item put into it. It uses a
-    manager-provided queue for robust inter-process sharing.
+    A multiprocessing queue sink that, on the first 'put' operation,
+    selects an underlying queue (Torch or default) based on the item type.
+    It sends a coordination message on the default queue before using the
+    selected queue.
     """
 
     def __init__(
         self,
-        shared_manager_dict: DictProxy,  # type: ignore[type-arg]
-        shared_lock: threading.Lock,
-        manager_instance: SyncManager,
+        default_sink: MultiprocessQueueSink[_QueueItemType],
+        torch_sink: Optional[MultiprocessQueueSink[_QueueItemType]],
+        # The coordination messages are strings, so the default_sink must be able to handle them.
+        # We assume _QueueItemType can be a string for this coordination message.
+        # If _QueueItemType is strictly not a string, this would need adjustment.
+        # For now, the coordination channel (default_sink) is typed with _QueueItemType.
+        # A more robust solution might use a dedicated control queue for strings.
     ):
         """
-        Initializes the DelegatingQueueSink.
+        Initializes the DelegatingMultiprocessQueueSink.
 
         Args:
-            shared_manager_dict: A manager-created dictionary for shared state.
-            shared_lock: A manager-created lock for synchronizing access to shared_dict.
-            manager_instance: The multiprocessing SyncManager instance.
+            default_sink: The sink for the default multiprocessing queue.
+                         This queue is also used for the initial coordination message.
+            torch_sink: The sink for the PyTorch multiprocessing queue, if available.
         """
-        self.__shared_dict = shared_manager_dict
-        self.__shared_lock = shared_lock
-        self.__manager = manager_instance
-        self.__real_sink_internal: Optional[
-            MultiprocessQueueSink[QueueItemType]
-        ] = None
+        self.__default_sink = default_sink
+        self.__torch_sink = torch_sink
+        self.__selected_queue_type: Optional[SelectedQueueType] = None
         self.__closed_flag = False
 
-    def __initialize_real_sink(self, item: QueueItemType) -> None:
-        """
-        Initializes the actual underlying queue on the first put operation or
-        adopts an existing shared queue if already initialized by another process.
-        """
-        if self.__real_sink_internal is not None:
-            return
+    def _select_queue_and_send_coordination(
+        self, item: _QueueItemType
+    ) -> None:
+        """Selects queue based on item type and sends coordination message."""
+        actual_data = getattr(item, "data", item)
 
-        with self.__shared_lock:
-            # Re-check inside lock for thread-safety for this instance's attribute
-            if self.__real_sink_internal is not None:
-                return
-
-            if not self.__shared_dict.get(INITIALIZED_KEY, False):
-                # This process is the first to initialize the shared queue
-                actual_data = getattr(item, "data", item)
-
-                queue_factory: MultiprocessQueueFactory[QueueItemType]
-
-                if (
-                    is_torch_available()
-                    and _torch_mp_module is not None
-                    and isinstance(actual_data, torch.Tensor)
-                ):
-                    queue_factory = TorchMultiprocessQueueFactory(
-                        manager=self.__manager
-                    )
-                else:
-                    queue_factory = DefaultMultiprocessQueueFactory(
-                        manager=self.__manager
-                    )
-
-                real_sink_instance, real_source_instance = (
-                    queue_factory.create_queues()
-                )
-
-                self.__shared_dict[REAL_QUEUE_SINK_REF_KEY] = (
-                    real_sink_instance
-                )
-                self.__shared_dict[REAL_QUEUE_SOURCE_REF_KEY] = (
-                    real_source_instance
-                )
-                self.__shared_dict[INITIALIZED_KEY] = True
-                self.__real_sink_internal = real_sink_instance
-            else:
-                # Queue already initialized by another process. This instance needs to adopt it.
-                # The SINK itself is what this instance needs for its __real_sink_internal
-                sink_ref = self.__shared_dict.get(REAL_QUEUE_SINK_REF_KEY)
-                if isinstance(sink_ref, MultiprocessQueueSink):
-                    self.__real_sink_internal = sink_ref
-                elif sink_ref is None:
-                    raise RuntimeError(
-                        "Queue initialized but REAL_QUEUE_SINK_REF_KEY is missing in shared_dict."
-                    )
-                else:
-                    raise RuntimeError(
-                        f"Invalid sink_ref type in shared_dict: {type(sink_ref)}"
-                    )
-
-        assert (
-            self.__real_sink_internal is not None
-        ), "Sink internal not initialized after __initialize_real_sink"
+        if (
+            _TORCH_AVAILABLE
+            and self.__torch_sink is not None
+            and _torch_tensor_type
+            is not None  # Make sure torch.Tensor was imported
+            and isinstance(actual_data, _torch_tensor_type)
+        ):
+            # Using type: ignore as put_nowait expects _QueueItemType, but we're sending a string.
+            # This implies _QueueItemType must be compatible with str for coordination.
+            self.__default_sink.put_nowait(USE_TORCH_QUEUE_MSG)  # type: ignore
+            self.__selected_queue_type = "torch"
+        else:
+            self.__default_sink.put_nowait(USE_DEFAULT_QUEUE_MSG)  # type: ignore
+            self.__selected_queue_type = "default"
 
     def put_blocking(
-        self, obj: QueueItemType, timeout: Optional[float] = None
+        self, obj: _QueueItemType, timeout: Optional[float] = None
     ) -> bool:
-        """Puts an item into the queue, blocking if necessary."""
+        """Puts an item into the selected queue, blocking if necessary."""
         if self.__closed_flag:
             raise RuntimeError("Sink closed.")
-        if self.__real_sink_internal is None:
-            self.__initialize_real_sink(obj)
 
-        if self.__real_sink_internal is None:
-            raise RuntimeError(
-                "Sink not init for put_blocking (remained None after init or adoption attempt)."
-            )
-        return self.__real_sink_internal.put_blocking(obj, timeout=timeout)
+        if self.__selected_queue_type is None:
+            self._select_queue_and_send_coordination(obj)
+            # The first item still needs to be put after coordination.
 
-    def put_nowait(self, obj: QueueItemType) -> bool:
-        """Puts an item into the queue without blocking."""
+        if self.__selected_queue_type == "torch":
+            if (
+                self.__torch_sink is None
+            ):  # Should not happen if selected_queue_type is "torch"
+                raise RuntimeError("Torch sink selected but not available.")
+            return self.__torch_sink.put_blocking(obj, timeout=timeout)
+        # Default to default_sink if not torch (covers "default" or if torch somehow became None)
+        return self.__default_sink.put_blocking(obj, timeout=timeout)
+
+    def put_nowait(self, obj: _QueueItemType) -> bool:
+        """Puts an item into the selected queue without blocking."""
         if self.__closed_flag:
             raise RuntimeError("Sink closed.")
-        if self.__real_sink_internal is None:
-            self.__initialize_real_sink(obj)
 
-        if self.__real_sink_internal is None:
-            raise RuntimeError(
-                "Sink not init for put_nowait (remained None after init or adoption attempt)."
-            )
-        return self.__real_sink_internal.put_nowait(obj)
+        if self.__selected_queue_type is None:
+            self._select_queue_and_send_coordination(obj)
+            # The first item still needs to be put after coordination.
+
+        if self.__selected_queue_type == "torch":
+            if self.__torch_sink is None:  # Should not happen
+                raise RuntimeError(
+                    "Torch sink selected but not available for put_nowait."
+                )
+            return self.__torch_sink.put_nowait(obj)
+        return self.__default_sink.put_nowait(obj)
 
     def close(self) -> None:
-        """Marks the sink as closed."""
+        """Marks the sink as closed. Does not close underlying sinks here,
+        as they are managed by the factory that created them."""
         self.__closed_flag = True
+        # Optionally, could call close on underlying sinks if ownership is here,
+        # but typically factory handles lifecycle of underlying queues.
+        # self.__default_sink.close()
+        # if self.__torch_sink:
+        #     self.__torch_sink.close()
 
     @property
     def closed(self) -> bool:
@@ -195,166 +165,189 @@ class DelegatingMultiprocessQueueSink(MultiprocessQueueSink[QueueItemType]):
 
 # pylint: disable=W0231
 class DelegatingMultiprocessQueueSource(
-    MultiprocessQueueSource[QueueItemType]
+    MultiprocessQueueSource[_QueueItemType]
 ):
     """
-    A multiprocessing queue source that waits for the corresponding sink
-    to initialize the actual queue. It polls a shared dictionary to find
-    the reference to the real queue source.
+    A multiprocessing queue source that first reads a coordination message
+    from the default queue to determine which underlying queue (Torch or default)
+    to use for all subsequent 'get' operations.
     """
 
     def __init__(
         self,
-        shared_manager_dict: DictProxy,  # type: ignore[type-arg]
-        shared_lock: threading.Lock,
+        default_source: MultiprocessQueueSource[_QueueItemType],
+        torch_source: Optional[MultiprocessQueueSource[_QueueItemType]],
     ):
         """
-        Initializes the DelegatingQueueSource.
+        Initializes the DelegatingMultiprocessQueueSource.
 
         Args:
-            shared_manager_dict: A manager-created dictionary for shared state.
-            shared_lock: A manager-created lock for synchronizing access.
+            default_source: The source for the default multiprocessing queue.
+                            This queue is also used for the initial coordination message.
+            torch_source: The source for the PyTorch multiprocessing queue, if available.
         """
-        self.__shared_dict = shared_manager_dict
-        self.__shared_lock = shared_lock
-        self.__real_source_internal: Optional[
-            MultiprocessQueueSource[QueueItemType]
+        self.__default_source = default_source
+        self.__torch_source = torch_source
+        self.__underlying_source_to_use: Optional[
+            MultiprocessQueueSource[_QueueItemType]
         ] = None
 
-    def _ensure_real_source_initialized(
-        self, polling_timeout: Optional[float] = None
+    def _receive_coordination_and_select_source(
+        self, timeout: Optional[float] = None
     ) -> None:
-        """
-        Waits for the sink to initialize and populate the shared dictionary
-        with the reference to the actual queue source.
-
-        Args:
-            polling_timeout: Optional timeout for waiting for initialization.
-
-        Raises:
-            queue.Empty: If timeout occurs while waiting for initialization.
-            RuntimeError: If the shared state is inconsistent.
-        """
-        if self.__real_source_internal is not None:
+        """Receives coordination message and sets the appropriate underlying source."""
+        if self.__underlying_source_to_use is not None:
             return
-        start_time = time.monotonic()
-        while True:
-            if (
-                self.__real_source_internal is not None
-            ):  # Check again in case of concurrent modification
-                return
-            with self.__shared_lock:
-                if self.__shared_dict.get(INITIALIZED_KEY, False):
-                    source_ref = self.__shared_dict.get(
-                        REAL_QUEUE_SOURCE_REF_KEY
-                    )
-                    if isinstance(source_ref, MultiprocessQueueSource):
-                        self.__real_source_internal = source_ref
-                        return
-                    if source_ref is None:
-                        raise RuntimeError("Q init but source_ref missing.")
-                    raise RuntimeError(
-                        f"Invalid source_ref type: {type(source_ref)}."
-                    )
-            if polling_timeout is not None:
-                if (time.monotonic() - start_time) >= polling_timeout:
-                    raise queue.Empty(
-                        f"Timeout ({polling_timeout}s) for source init."
-                    )
-            time.sleep(0.01)
+
+        try:
+            # Blocking get for the coordination message from the default queue.
+            # This message is expected to be a string.
+            coordination_msg = self.__default_source.get_blocking(
+                timeout=timeout
+            )
+        except queue.Empty:  # Raised by get_blocking on timeout
+            # Propagate timeout if coordination message itself times out
+            raise
+
+        if coordination_msg == USE_TORCH_QUEUE_MSG:
+            if self.__torch_source is None:
+                raise RuntimeError(
+                    "Received USE_TORCH coordination, but no torch source is available."
+                )
+            self.__underlying_source_to_use = self.__torch_source
+        elif coordination_msg == USE_DEFAULT_QUEUE_MSG:
+            self.__underlying_source_to_use = self.__default_source
+        else:
+            # This case should ideally not happen if the sink sends valid messages.
+            raise RuntimeError(
+                f"Invalid coordination message received: {coordination_msg}"
+            )
 
     def get_blocking(
         self, timeout: Optional[float] = None
-    ) -> Optional[QueueItemType]:
-        """Gets an item from the queue, blocking if necessary."""
-        try:
-            self._ensure_real_source_initialized(polling_timeout=timeout)
-        except queue.Empty:
-            return None
-        if self.__real_source_internal is None:
-            return None
-        return self.__real_source_internal.get_blocking(timeout=timeout)
+    ) -> Optional[_QueueItemType]:
+        """Gets an item from the selected queue, blocking if necessary."""
+        if self.__underlying_source_to_use is None:
+            try:
+                self._receive_coordination_and_select_source(timeout=timeout)
+            except queue.Empty:  # Timeout receiving coordination message
+                return None  # Consistent with how get_blocking typically signals timeout
 
-    def get_or_none(self) -> Optional[QueueItemType]:
-        """Gets an item from the queue if available, otherwise returns None."""
-        try:
-            self._ensure_real_source_initialized(
-                polling_timeout=0
-            )  # Short poll
-        except queue.Empty:
+        if self.__underlying_source_to_use is None:
+            # This should not be reached if _receive_coordination_and_select_source succeeded
+            # or if it timed out (which should have returned None above).
+            raise RuntimeError(
+                "Underlying source not selected after coordination attempt."
+            )
+
+        # Now get the actual data item from the selected queue
+        return self.__underlying_source_to_use.get_blocking(timeout=timeout)
+
+    def get_or_none(self) -> Optional[_QueueItemType]:
+        """Gets an item from the selected queue if available, otherwise returns None."""
+        if self.__underlying_source_to_use is None:
+            try:
+                # Use a short timeout or non-blocking for coordination if this method is non-blocking.
+                # If get_blocking on default_source can return None immediately if empty, that's better.
+                # Assuming get_blocking with timeout=0 or a very small value for check.
+                self._receive_coordination_and_select_source(
+                    timeout=0.001
+                )  # Small timeout for check
+            except queue.Empty:  # Timeout or empty during coordination check
+                return None  # Can't determine queue, so no item.
+
+        if self.__underlying_source_to_use is None:
+            # Still no source selected (e.g. coordination timed out above, or not yet sent)
             return None
-        if self.__real_source_internal is None:
-            return None
-        return self.__real_source_internal.get_or_none()
+
+        # Now get the actual data item from the selected queue
+        return self.__underlying_source_to_use.get_or_none()
 
 
 class DelegatingMultiprocessQueueFactory(
-    MultiprocessQueueFactory[QueueItemType], Generic[QueueItemType]
+    MultiprocessQueueFactory[_QueueItemType], Generic[_QueueItemType]
 ):
     """
-    A factory that creates pairs of DelegatingQueueSink and DelegatingQueueSource.
-    It manages an underlying multiprocessing manager (standard or Torch) which
-    is used by the sink to create the actual queues.
+    A factory that eagerly creates both default and PyTorch-specific queues
+    (if PyTorch is available) and provides delegating sink/source wrappers.
+    The sink/source pair uses a coordination mechanism on the default queue
+    to decide which underlying queue to use for actual data transfer.
     """
 
     def __init__(self) -> None:
         """Initializes the DelegatingMultiprocessQueueFactory."""
         super().__init__()
-        self.__manager: Optional[SyncManager] = None
+        # Each factory (default and torch) will manage its own manager if needed.
+        # This top-level factory doesn't need its own manager instance directly.
+        self.__default_factory: MultiprocessQueueFactory[_QueueItemType] = (
+            DefaultMultiprocessQueueFactory()
+        )
+        self.__torch_factory: Optional[
+            MultiprocessQueueFactory[_QueueItemType]
+        ] = None
 
-    def shutdown(self) -> None:
-        """Shuts down the underlying multiprocessing manager, if one was created."""
-        if self.__manager is not None:
-            try:
-                self.__manager.shutdown()
-            except Exception:  # pylint: disable=broad-except
-                # Intentionally broad: Log or handle specific shutdown errors if necessary.
-                # The primary goal is to ensure the manager reference is cleared.
-                pass
-            self.__manager = None
+        if _TORCH_AVAILABLE:
+            # Assuming TorchMultiprocessQueueFactory does not need a manager passed at init
+            # or handles it internally, similar to DefaultMultiprocessQueueFactory.
+            self.__torch_factory = TorchMultiprocessQueueFactory()
 
-    def __get_manager(self) -> SyncManager:
-        """
-        Gets or creates the appropriate multiprocessing manager instance.
-        Uses torch.multiprocessing.Manager if PyTorch is available,
-        otherwise defaults to standard multiprocessing.Manager.
-        """
-        if self.__manager is None:
-            if (
-                is_torch_available() and _torch_mp_module is not None
-            ):  # Use _torch_mp_module
-                self.__manager = _torch_mp_module.Manager()
-            else:
-                self.__manager = multiprocessing.Manager()
-        return self.__manager
+        # Create the queues eagerly
+        self.__default_sink_internal: MultiprocessQueueSink[_QueueItemType]
+        self.__default_source_internal: MultiprocessQueueSource[_QueueItemType]
+        (
+            self.__default_sink_internal,
+            self.__default_source_internal,
+        ) = self.__default_factory.create_queues()
+
+        self.__torch_sink_internal: Optional[
+            MultiprocessQueueSink[_QueueItemType]
+        ] = None
+        self.__torch_source_internal: Optional[
+            MultiprocessQueueSource[_QueueItemType]
+        ] = None
+
+        if self.__torch_factory:
+            (
+                self.__torch_sink_internal,
+                self.__torch_source_internal,
+            ) = self.__torch_factory.create_queues()
 
     def create_queues(
         self,
     ) -> Tuple[
-        MultiprocessQueueSink[QueueItemType],
-        MultiprocessQueueSource[QueueItemType],
+        MultiprocessQueueSink[_QueueItemType],
+        MultiprocessQueueSource[_QueueItemType],
     ]:
         """
         Creates a pair of delegating queue sink and source.
 
-        The sink and source will share a manager-created dictionary and lock
-        to coordinate the dynamic initialization of the actual queue.
+        These wrappers will use the eagerly created default and Torch queues.
         """
-        manager = self.__get_manager()
-        shared_lock = manager.Lock()
-        shared_dict = manager.dict()
-
-        shared_dict[INITIALIZED_KEY] = False
-        shared_dict[REAL_QUEUE_SOURCE_REF_KEY] = None
-        shared_dict[REAL_QUEUE_SINK_REF_KEY] = None
-
-        sink = DelegatingMultiprocessQueueSink[QueueItemType](
-            shared_manager_dict=shared_dict,
-            shared_lock=shared_lock,
-            manager_instance=manager,
+        # The sink and source wrappers are new instances each time,
+        # but they operate on the same underlying eagerly created queues.
+        sink = DelegatingMultiprocessQueueSink[_QueueItemType](
+            default_sink=self.__default_sink_internal,
+            torch_sink=self.__torch_sink_internal,
         )
-        source = DelegatingMultiprocessQueueSource[QueueItemType](
-            shared_manager_dict=shared_dict,
-            shared_lock=shared_lock,
+        source = DelegatingMultiprocessQueueSource[_QueueItemType](
+            default_source=self.__default_source_internal,
+            torch_source=self.__torch_source_internal,
         )
         return sink, source
+
+    def shutdown(self) -> None:
+        """Shuts down the underlying queue factories."""
+        if hasattr(self.__default_factory, "shutdown"):
+            self.__default_factory.shutdown()
+        if self.__torch_factory and hasattr(self.__torch_factory, "shutdown"):
+            self.__torch_factory.shutdown()
+
+
+# Remove old helper, no longer used with eager creation.
+# def is_torch_available() -> bool:
+#    return _TORCH_AVAILABLE
+
+# Remove old constants, not used in the new design
+# INITIALIZED_KEY = "initialized"
+# REAL_QUEUE_SOURCE_REF_KEY = "real_queue_source_ref"
+# REAL_QUEUE_SINK_REF_KEY = "real_queue_sink_ref"

--- a/tsercom/threading/multiprocess/delegating_multiprocess_queue_factory_unittest.py
+++ b/tsercom/threading/multiprocess/delegating_multiprocess_queue_factory_unittest.py
@@ -1,19 +1,22 @@
-"""Unit tests for DelegatingMultiprocessQueueFactory and its components."""
+"""Unit tests for DelegatingMultiprocessQueueFactory and its components
+with the new eager creation, lazy selection architecture."""
 
 import pytest
 from pytest_mock import MockerFixture
 import multiprocessing
-import multiprocessing.synchronize as mp_sync
 import time
 from typing import Any, List, Optional, cast, TypeAlias, Dict
 import types
-import queue
-import warnings
+import queue  # For queue.Empty
 
+# Module under test
 import tsercom.threading.multiprocess.delegating_multiprocess_queue_factory as dqf_module
 from tsercom.threading.multiprocess.delegating_multiprocess_queue_factory import (
     DelegatingMultiprocessQueueSink,
     DelegatingMultiprocessQueueSource,
+    DelegatingMultiprocessQueueFactory,
+    USE_TORCH_QUEUE_MSG,
+    USE_DEFAULT_QUEUE_MSG,
 )
 from tsercom.threading.multiprocess.multiprocess_queue_sink import (
     MultiprocessQueueSink,
@@ -21,12 +24,23 @@ from tsercom.threading.multiprocess.multiprocess_queue_sink import (
 from tsercom.threading.multiprocess.multiprocess_queue_source import (
     MultiprocessQueueSource,
 )
+from tsercom.threading.multiprocess.default_multiprocess_queue_factory import (
+    DefaultMultiprocessQueueFactory,
+)
+from tsercom.threading.multiprocess.torch_multiprocess_queue_factory import (
+    TorchMultiprocessQueueFactory,
+)
+
 
 # Conditional import strategy for torch and torch.multiprocessing for type checking
 _torch_installed = False
 _real_torch_imported_module: Optional[types.ModuleType] = None
-torch_module: Optional[types.ModuleType] = None
-torch_mp_module: Optional[types.ModuleType] = None
+torch_module: Optional[types.ModuleType] = (
+    None  # For tests to use torch.tensor etc.
+)
+torch_mp_module: Optional[types.ModuleType] = (
+    None  # For torch.multiprocessing specific things
+)
 
 try:
     import torch as _imported_torch_real
@@ -36,1410 +50,1225 @@ try:
     torch_module = _imported_torch_real
     torch_mp_module = _imported_torch_mp_real
     _torch_installed = True
+    TensorType: TypeAlias = _imported_torch_real.Tensor
 except ImportError:
+    TensorType: TypeAlias = Any  # Placeholder if torch not installed
 
-    class Tensor:  # Placeholder class for when torch is not available
+    class MockTensor:
         pass
 
-    if not torch_module:
-        torch_mock = MockerFixture(None).MagicMock()
-        torch = torch_mock  # type: ignore[assignment]
-        if hasattr(torch, "Tensor"):
-            torch.Tensor = Tensor  # type: ignore[misc]
-    if not torch_mp_module:
-        torch_mp_mock = MockerFixture(None).MagicMock()
-        torch_mp = torch_mp_mock  # type: ignore[assignment]
+    if (
+        not hasattr(globals(), "torch_module")
+        or globals()["torch_module"] is None
+    ):
+
+        class FallbackTorchMock:
+            Tensor = MockTensor
+
+            def __getattr__(self, name):
+                return FallbackTorchMock()
+
+            def __call__(self, *args, **kwargs):
+                return FallbackTorchMock()
+
+        globals()["torch_module"] = FallbackTorchMock()  # type: ignore
+        globals()["torch_mp_module"] = FallbackTorchMock()  # type: ignore
 
 
-if _torch_installed and _real_torch_imported_module:
-    TensorType: TypeAlias = _real_torch_imported_module.Tensor
-else:
-    TensorType: TypeAlias = Any
+def get_mp_context():
+    if (
+        _torch_installed
+        and torch_mp_module
+        and hasattr(torch_mp_module, "get_context")
+    ):
+        # Prefer torch.multiprocessing if available and configured
+        try:
+            # Check if a context is already set, which is a good sign it's usable
+            # get_start_method will throw error if not initialized on some OS, so be careful
+            # If get_context() itself works, it's a good sign.
+            return torch_mp_module.get_context()
+        except Exception:  # Fallback if torch.mp context isn't quite ready
+            pass
+    return multiprocessing.get_context()
 
 
-def set_torch_mp_start_method_if_needed(method: str = "spawn") -> None:
-    """
-    Sets the multiprocessing start method for torch.multiprocessing.
-    Attempts to be robust to multiple calls or pre-set contexts.
-    """
-    if not (
+def set_torch_mp_start_method_if_needed(
+    method: str = "spawn", force: bool = True
+) -> None:
+    mp_context_to_use = multiprocessing
+    context_name = "standard multiprocessing"
+    can_use_torch_mp = False
+
+    if (
         _torch_installed
         and torch_mp_module
         and hasattr(torch_mp_module, "get_start_method")
         and hasattr(torch_mp_module, "set_start_method")
     ):
-        if method == "spawn" and not torch_mp_module:
-            try:
-                multiprocessing.set_start_method(method, force=True)
+        # Check if torch.multiprocessing has already been initialized
+        # If get_start_method doesn't raise an error and returns a value, it's likely initialized.
+        try:
+            # if torch_mp_module.get_start_method(allow_none=True) is not None or method == "fork": # fork can sometimes be set implicitly
+            mp_context_to_use = torch_mp_module  # type: ignore
+            context_name = "Torch multiprocessing"
+            can_use_torch_mp = True
+        except RuntimeError:  # Not initialized yet
+            if (
+                multiprocessing.get_start_method(allow_none=True) is None
+            ):  # if std mp is also not set, try setting torch mp
+                mp_context_to_use = torch_mp_module  # type: ignore
+                context_name = "Torch multiprocessing"
+                can_use_torch_mp = True
+            else:  # std mp is set, torch mp is not, stick to std mp to avoid conflict
                 print(
-                    f"Successfully set standard multiprocessing start_method to '{method}'."
+                    f"Torch MP context not available or std MP already set to {multiprocessing.get_start_method(allow_none=True)}. Using std MP for setting start method."
                 )
-            except RuntimeError as e:  # pragma: no cover
-                current_method_after_error = multiprocessing.get_start_method(
-                    allow_none=True
-                )
-                if current_method_after_error != method:
-                    print(
-                        f"Warning: Standard MP: Could not set start_method to '{method}'. Current: '{current_method_after_error}'. Error: {e}"
-                    )
-                    if "context has already been set" in str(
-                        e
-                    ) or "cannot start a process after starting a new process" in str(
-                        e
-                    ):
-                        raise RuntimeError(
-                            f"Standard MP context is '{current_method_after_error}', "
-                            f"cannot change to '{method}'. Test requires '{method}'."
-                        ) from e
-        return
+                pass
 
     try:
-        current_method = torch_mp_module.get_start_method(allow_none=True)
-        if current_method == method:
-            print(f"Torch MP start_method already set to '{method}'.")
+        current_method = mp_context_to_use.get_start_method(allow_none=True)
+        if current_method == method and not force:
+            print(f"{context_name} start_method already set to '{method}'.")
             return
 
-        torch_mp_module.set_start_method(method, force=True)
-        print(f"Successfully set Torch MP start_method to '{method}'.")
-
-    except RuntimeError as e:  # pragma: no cover
-        current_method_after_error = torch_mp_module.get_start_method(
-            allow_none=True
-        )
-        err_msg = str(e).lower()
-
-        if current_method_after_error == method:
+        # For "fork", if it's already the method, setting it again (even with force=True)
+        # can cause "cannot start a process after starting a new process" if any process (e.g. manager) has started.
+        # So, if current_method is already 'fork' and we want 'fork', just return.
+        if current_method == method and method == "fork":
             print(
-                f"Torch MP start_method is '{method}' (error during forced set: '{err_msg}'). Assuming context is as desired."
+                f"{context_name} start_method already '{method}'. Skipping set_start_method."
             )
             return
 
-        context_already_set = "context has already been set" in err_msg
-        processes_already_started = (
-            "cannot start a process after starting a new process" in err_msg
-        )
+        mp_context_to_use.set_start_method(method, force=force)  # type: ignore
+        print(f"Successfully set {context_name} start_method to '{method}'.")
 
+    except RuntimeError as e:
+        current_method_after_error = mp_context_to_use.get_start_method(
+            allow_none=True
+        )
+        if current_method_after_error == method:
+            print(
+                f"{context_name} start_method is '{method}' (error during forced set: '{e}'). Assuming context is as desired."
+            )
+            return
+
+        err_str = str(e).lower()
         if (
-            context_already_set or processes_already_started
-        ) and current_method_after_error != method:
+            "context has already been set" in err_str
+            or "cannot start a process after starting a new process" in err_str
+        ):
+            if current_method_after_error != method:
+                # If we are trying to set to 'spawn' and it's already 'fork', this is a critical issue for tests needing 'spawn'.
+                # If torch mp was desired but we fell back to std mp, and std mp is wrong, also critical.
+                accept_current = False
+                if (
+                    can_use_torch_mp
+                    and mp_context_to_use != torch_mp_module
+                    and multiprocessing.get_start_method(allow_none=True)
+                    == method
+                ):
+                    # Fell back to std mp, but std mp is already the desired method
+                    print(
+                        f"Standard MP context is already '{method}'. Using it."
+                    )
+                    accept_current = True
+
+                if not accept_current:
+                    raise RuntimeError(
+                        f"{context_name} context is '{current_method_after_error}' and cannot be changed to '{method}'. "
+                        f"Test requires '{method}'. Original error: {e}"
+                    ) from e
+            else:  # context already set, and it's the one we want
+                print(
+                    f"{context_name} context was already '{method}'. Proceeding."
+                )
+        else:  # Other runtime error
+            raise
+    except Exception as e:
+        current_method_final = mp_context_to_use.get_start_method(
+            allow_none=True
+        )
+        if current_method_final != method:  # Final check
             raise RuntimeError(
-                f"Torch MP context is '{current_method_after_error}' and cannot be changed to '{method}'. "
-                f"Test requires '{method}'. Original error: {e}"
+                f"Failed to set {context_name} start method to '{method}'. Current: '{current_method_final}'. Error: {e}"
             ) from e
-        raise
-    except Exception as e:  # pragma: no cover
-        print(
-            f"An unexpected error occurred while setting start method to '{method}': {e}"
-        )
-        raise
-
-
-# Top-level worker functions
-def sink_process_worker(  # Original worker - kept for other tests if they use it
-    barrier: mp_sync.Barrier,
-    results_q: multiprocessing.Queue,
-    delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    item_to_put: Any,
-    process_id: Any,
-) -> None:
-    try:
-        barrier.wait(timeout=5)
-        success = delegating_sink.put_nowait(item_to_put)
-        if not success:
-            results_q.put((process_id, "put_fail_full", None))
-            return
-        results_q.put((process_id, "put_success", item_to_put))
-    except Exception as e:  # pragma: no cover
-        results_q.put((process_id, "put_exception", e))
-
-
-def source_process_worker(  # Original worker
-    barrier: Optional[mp_sync.Barrier],
-    results_q: multiprocessing.Queue,
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    num_items_to_get: int,
-    process_id: Any,
-) -> None:
-    items_received: List[Any] = []
-    try:
-        if barrier:
-            barrier.wait(timeout=5)
-        for _ in range(num_items_to_get):
-            item = delegating_source.get_blocking(timeout=2)
-            if item is None:
-                results_q.put((process_id, "get_timeout", items_received))
-                return
-            items_received.append(item)
-        results_q.put((process_id, "get_success", items_received))
-    except Exception as e:  # pragma: no cover
-        results_q.put((process_id, "get_exception", e))
-
-
-def source_process_worker_ipc(  # Original worker
-    results_q: multiprocessing.Queue,
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    sentinel: Any,
-    process_id: Any,
-) -> None:
-    items_received: List[Any] = []
-    try:
-        while True:
-            item = delegating_source.get_blocking(timeout=5)
-            if item == sentinel:
-                break
-            if item is None:
-                results_q.put(("get_timeout", items_received))
-                return
-            items_received.append(item)
-        results_q.put(("get_success", items_received))
-    except Exception as e:  # pragma: no cover
-        results_q.put(("get_exception", e))
-
-
-# Worker for default item MP correctness tests
-def _producer_worker_default(
-    sink_queue: dqf_module.DelegatingMultiprocessQueueSink[Dict[str, Any]],
-    item_to_send: Dict[str, Any],
-    result_queue: "torch_mp_module.Queue[str]",  # type: ignore[name-defined]
-):
-    try:
-        if not sink_queue.put_blocking(item_to_send, timeout=10):
-            result_queue.put("put_failed_timeout_or_full")
-            return
-        result_queue.put("put_successful")
-    except Exception as e:  # pragma: no cover
-        import traceback
-
-        tb_str = traceback.format_exc()
-        result_queue.put(
-            f"producer_exception: {type(e).__name__}: {e}\n{tb_str}"
-        )
-
-
-def _consumer_worker_default(
-    source_queue: dqf_module.DelegatingMultiprocessQueueSource[Dict[str, Any]],
-    result_queue: "torch_mp_module.Queue[Any]",  # type: ignore[name-defined]
-):
-    try:
-        item = source_queue.get_blocking(timeout=15)
-        result_queue.put(item)
-    except queue.Empty:  # pragma: no cover
-        result_queue.put("get_failed_timeout_empty")
-    except Exception as e:  # pragma: no cover
-        import traceback
-
-        tb_str = traceback.format_exc()
-        result_queue.put(
-            f"consumer_exception: {type(e).__name__}: {e}\n{tb_str}"
-        )
-
-
-# Worker functions for tensor MP correctness tests
-def _producer_worker_tensor(
-    sink_queue: dqf_module.DelegatingMultiprocessQueueSink[TensorType],
-    item_to_send: TensorType,
-    result_queue: "torch_mp_module.Queue[str]",  # type: ignore[name-defined]
-):
-    try:
-        if not sink_queue.put_blocking(item_to_send, timeout=10):
-            result_queue.put("put_failed_timeout_or_full")
-            return
-        result_queue.put("put_successful")
-    except Exception as e:  # pragma: no cover
-        import traceback
-
-        tb_str = traceback.format_exc()
-        result_queue.put(
-            f"producer_exception: {type(e).__name__}: {e}\n{tb_str}"
-        )
-
-
-def _consumer_worker_tensor(
-    source_queue: dqf_module.DelegatingMultiprocessQueueSource[TensorType],
-    result_queue: "torch_mp_module.Queue[Any]",  # type: ignore[name-defined]
-):
-    try:
-        item = source_queue.get_blocking(timeout=15)
-        result_queue.put(item)
-    except queue.Empty:  # pragma: no cover
-        result_queue.put("get_failed_timeout_empty")
-    except Exception as e:  # pragma: no cover
-        import traceback
-
-        tb_str = traceback.format_exc()
-        result_queue.put(
-            f"consumer_exception: {type(e).__name__}: {e}\n{tb_str}"
-        )
-
-
-# Worker function for initialization race condition test
-def _race_condition_producer_worker(
-    manager_proxy: Any,  # Actual manager instance from parent
-    shared_dict_proxy: Any,  # Manager.dict proxy
-    shared_lock_proxy: Any,  # Manager.Lock proxy
-    item_to_send: Any,
-    result_queue: "torch_mp_module.Queue[str]",  # type: ignore[name-defined]
-    process_id: int,
-    barrier: "torch_mp_module.Barrier",  # type: ignore[name-defined]
-):
-    try:
-        # Each worker creates its own sink instance using shared components
-        # The manager_proxy is crucial here if the sink needs to create manager-dependent queues
-        sink_queue_instance = dqf_module.DelegatingMultiprocessQueueSink[Any](
-            shared_manager_dict=shared_dict_proxy,
-            shared_lock=shared_lock_proxy,
-            manager_instance=manager_proxy,
-        )
-
-        barrier.wait(timeout=10)  # Synchronize start
-
-        if not sink_queue_instance.put_blocking(item_to_send, timeout=10):
-            result_queue.put(f"put_failed_producer_{process_id}")
-            return
-        result_queue.put(f"put_successful_producer_{process_id}")
-    except Exception as e:  # pragma: no cover
-        import traceback
-
-        tb_str = traceback.format_exc()
-        result_queue.put(
-            f"producer_{process_id}_exception: {type(e).__name__}: {e}\n{tb_str}"
-        )
-
-
-# --- Existing Fixtures ---
-@pytest.fixture
-def mock_is_torch_available(mocker: MockerFixture) -> MockerFixture:
-    return mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.is_torch_available"
-    )
 
 
 @pytest.fixture
-def MockStdManager(mocker: MockerFixture) -> MockerFixture:
-    return mocker.patch("multiprocessing.Manager")
+def mock_default_queue_factory(mocker: MockerFixture) -> MockerFixture:
+    mock = mocker.MagicMock(spec=DefaultMultiprocessQueueFactory)
+    mock.create_queues.return_value = (
+        mocker.MagicMock(spec=MultiprocessQueueSink),
+        mocker.MagicMock(spec=MultiprocessQueueSource),
+    )
+    return mock
 
 
 @pytest.fixture
-def MockTorchManager(mocker: MockerFixture) -> MockerFixture:
-    if _torch_installed and torch_mp_module:
-        return mocker.patch.object(torch_mp_module, "Manager")
-    return mocker.MagicMock()
+def mock_torch_queue_factory(mocker: MockerFixture) -> MockerFixture:
+    if not _torch_installed:
+        # Return a simple mock if torch isn't there, it shouldn't be used anyway by factory
+        dummy_mock = mocker.MagicMock()
+        dummy_mock.create_queues.return_value = (
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+        )
+        return dummy_mock
 
-
-# ... (all other existing test functions and fixtures up to delegating_mp_factory) ...
-def test_factory_init_defaults() -> None:
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
+    mock = mocker.MagicMock(spec=TorchMultiprocessQueueFactory)
+    mock.create_queues.return_value = (
+        mocker.MagicMock(spec=MultiprocessQueueSink),
+        mocker.MagicMock(spec=MultiprocessQueueSource),
     )
-    assert factory._DelegatingMultiprocessQueueFactory__manager is None
+    return mock
 
 
-def test_get_manager_std_manager_when_torch_unavailable(
-    mock_is_torch_available: MockerFixture,
-    MockStdManager: MockerFixture,
-    MockTorchManager: MockerFixture,
-) -> None:
-    mock_is_torch_available.return_value = False
-    mock_std_manager_instance = MockStdManager.return_value
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
+@pytest.fixture
+def delegating_factory_instance(
+    mocker: MockerFixture,
+    mock_default_queue_factory: MockerFixture,
+    mock_torch_queue_factory: MockerFixture,
+) -> DelegatingMultiprocessQueueFactory[Any]:
+    mocker.patch(
+        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory",
+        return_value=mock_default_queue_factory,
     )
-    manager1 = factory._DelegatingMultiprocessQueueFactory__get_manager()
-    MockStdManager.assert_called_once()
+    # Only patch TorchMultiprocessQueueFactory if torch is considered installed by the test environment
     if _torch_installed:
-        MockTorchManager.assert_not_called()
-    assert manager1 is mock_std_manager_instance
-    manager2 = factory._DelegatingMultiprocessQueueFactory__get_manager()
-    MockStdManager.assert_called_once()
-    assert manager2 is manager1
-
-
-@pytest.mark.skipif(not _torch_installed, reason="PyTorch not installed.")
-def test_get_manager_torch_manager_when_torch_available(
-    mock_is_torch_available: MockerFixture,
-    MockStdManager: MockerFixture,
-    MockTorchManager: MockerFixture,
-) -> None:
-    mock_is_torch_available.return_value = True
-    mock_torch_manager_instance = MockTorchManager.return_value
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
-    )
-    manager1 = factory._DelegatingMultiprocessQueueFactory__get_manager()
-    MockTorchManager.assert_called_once()
-    MockStdManager.assert_not_called()
-    assert manager1 is mock_torch_manager_instance
-    manager2 = factory._DelegatingMultiprocessQueueFactory__get_manager()
-    MockTorchManager.assert_called_once()
-    assert manager2 is manager1
-
-
-def test_create_queues_uses_manager_and_returns_sink_source(
-    mocker: MockerFixture, mock_is_torch_available: MockerFixture
-) -> None:
-    mock_is_torch_available.return_value = False
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
-    )
-    mock_manager_instance: Any = mocker.MagicMock()
-    mock_lock: Any = mocker.MagicMock(spec=mp_sync.Lock)
-    mock_dict: Any = mocker.MagicMock(spec=dict)
-    mock_manager_instance.Lock.return_value = mock_lock
-    mock_manager_instance.dict.return_value = mock_dict
-
-    patched_get_manager_mock = mocker.MagicMock(
-        return_value=mock_manager_instance
-    )
-
-    mocker.patch.object(
-        factory,
-        "_DelegatingMultiprocessQueueFactory__get_manager",
-        new=patched_get_manager_mock,
-    )
-
-    MockedSink = mocker.patch.object(
-        dqf_module, "DelegatingMultiprocessQueueSink"
-    )
-    MockedSource = mocker.patch.object(
-        dqf_module, "DelegatingMultiprocessQueueSource"
-    )
-
-    intermediate_sink_mock = mocker.MagicMock()
-    MockedSink.__getitem__.return_value = intermediate_sink_mock
-
-    intermediate_source_mock = mocker.MagicMock()
-    MockedSource.__getitem__.return_value = intermediate_source_mock
-
-    mock_sink_instance = intermediate_sink_mock.return_value
-    mock_source_instance = intermediate_source_mock.return_value
-
-    sink, source = factory.create_queues()
-
-    patched_get_manager_mock.assert_called_once()
-    mock_manager_instance.Lock.assert_called_once()
-    mock_manager_instance.dict.assert_called_once()
-    mock_dict.__setitem__.assert_any_call("initialized", False)
-    mock_dict.__setitem__.assert_any_call("real_queue_source_ref", None)
-
-    intermediate_sink_mock.assert_called_once_with(
-        shared_manager_dict=mock_dict,
-        shared_lock=mock_lock,
-        manager_instance=mock_manager_instance,
-    )
-    intermediate_source_mock.assert_called_once_with(
-        shared_manager_dict=mock_dict, shared_lock=mock_lock
-    )
-    assert sink is mock_sink_instance
-    assert source is mock_source_instance
-
-
-def test_shutdown_no_manager_created() -> None:
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
-    )
-    assert (
-        factory._DelegatingMultiprocessQueueFactory__manager is None
-    ), "Manager should be None initially."
-    factory.shutdown()
-    assert (
-        factory._DelegatingMultiprocessQueueFactory__manager is None
-    ), "Manager should still be None after shutdown."
-
-
-def test_shutdown_with_active_manager(
-    mocker: MockerFixture,
-    mock_is_torch_available: MockerFixture,
-    MockStdManager: MockerFixture,
-) -> None:
-    mock_is_torch_available.return_value = False
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
-    )
-    manager_instance = (
-        factory._DelegatingMultiprocessQueueFactory__get_manager()
-    )
-    assert factory._DelegatingMultiprocessQueueFactory__manager is not None
-    assert (
-        factory._DelegatingMultiprocessQueueFactory__manager
-        is manager_instance
-    )
-    assert manager_instance is MockStdManager.return_value
-
-    MockStdManager.return_value.shutdown = mocker.MagicMock()
-    factory.shutdown()
-    MockStdManager.return_value.shutdown.assert_called_once()
-    assert factory._DelegatingMultiprocessQueueFactory__manager is None
-
-
-def test_shutdown_manager_shutdown_raises_exception(
-    mocker: MockerFixture,
-    mock_is_torch_available: MockerFixture,
-    MockStdManager: MockerFixture,
-) -> None:
-    mock_is_torch_available.return_value = False
-    factory: dqf_module.DelegatingMultiprocessQueueFactory[Any] = (
-        dqf_module.DelegatingMultiprocessQueueFactory()
-    )
-    manager_instance = (
-        factory._DelegatingMultiprocessQueueFactory__get_manager()
-    )
-    assert factory._DelegatingMultiprocessQueueFactory__manager is not None
-    assert manager_instance is MockStdManager.return_value
-
-    MockStdManager.return_value.shutdown = mocker.MagicMock(
-        side_effect=RuntimeError("Manager shutdown failed")
-    )
-    try:
-        factory.shutdown()
-    except RuntimeError:  # pragma: no cover
-        pytest.fail(
-            "Factory.shutdown() should not re-raise manager's shutdown exception."
+        mocker.patch(
+            "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.TorchMultiprocessQueueFactory",
+            return_value=mock_torch_queue_factory,
         )
-    MockStdManager.return_value.shutdown.assert_called_once()
-    assert factory._DelegatingMultiprocessQueueFactory__manager is None
+
+    factory = DelegatingMultiprocessQueueFactory[Any]()
+    yield factory
+    factory.shutdown()
 
 
 @pytest.fixture
-def mock_shared_dict(mocker: MockerFixture) -> Any:
-    return mocker.MagicMock(spec=dict)
+def default_item() -> Dict[str, Any]:
+    return {
+        "type": "default",
+        "data": "some_data",
+        "id": 123,
+        "timestamp": time.time(),
+    }
 
 
 @pytest.fixture
-def mock_shared_lock(mocker: MockerFixture) -> Any:
-    return mocker.MagicMock(spec=mp_sync.Lock)
+def tensor_item(mocker: MockerFixture) -> Optional[TensorType]:
+    if not (_torch_installed and torch_module):
+        return None
+    return torch_module.tensor([1.0, 2.0, 3.0], dtype=torch_module.float32)
 
 
-@pytest.fixture
-def mock_manager_instance(mocker: MockerFixture) -> Any:
-    mock_manager_instance = mocker.MagicMock()
-    mock_manager_instance.Queue.return_value = mocker.MagicMock(
-        spec=multiprocessing.Queue
+def test_factory_init_eager_creation(
+    mocker: MockerFixture,
+) -> None:
+    MockedDefaultFactoryCons = mocker.patch(
+        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
     )
-    return mock_manager_instance
+    MockedTorchFactoryCons = mocker.patch(
+        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.TorchMultiprocessQueueFactory"
+    )
+
+    mock_default_factory_inst = MockedDefaultFactoryCons.return_value
+    mock_torch_factory_inst = MockedTorchFactoryCons.return_value
+
+    mock_default_factory_inst.create_queues.return_value = (
+        mocker.MagicMock(spec=MultiprocessQueueSink),
+        mocker.MagicMock(spec=MultiprocessQueueSource),
+    )
+    mock_torch_factory_inst.create_queues.return_value = (
+        mocker.MagicMock(spec=MultiprocessQueueSink),
+        mocker.MagicMock(spec=MultiprocessQueueSource),
+    )
+
+    original_torch_available = dqf_module._TORCH_AVAILABLE
+    dqf_module._TORCH_AVAILABLE = (
+        True  # Test the path where torch is considered available
+    )
+
+    factory = DelegatingMultiprocessQueueFactory[Any]()
+
+    MockedDefaultFactoryCons.assert_called_once()
+    mock_default_factory_inst.create_queues.assert_called_once()
+
+    # If _TORCH_AVAILABLE is true, Torch factory should be created.
+    # This relies on the actual _torch_installed at import time of dqf_module for the real code path,
+    # but here we are overriding dqf_module._TORCH_AVAILABLE for the test.
+    if dqf_module._TORCH_AVAILABLE:  # Check the overridden value
+        MockedTorchFactoryCons.assert_called_once()
+        mock_torch_factory_inst.create_queues.assert_called_once()
+    else:  # This case won't run due to override above, but good for completeness
+        MockedTorchFactoryCons.assert_not_called()
+        mock_torch_factory_inst.create_queues.assert_not_called()
+
+    dqf_module._TORCH_AVAILABLE = (
+        False  # Test the path where torch is considered unavailable
+    )
+    factory_no_torch = DelegatingMultiprocessQueueFactory[Any]()
+    # Default factory is called again because it's a new instance of DelegatingMultiprocessQueueFactory
+    # The mock counts calls on the class, not per instance of DelegatingMultiprocessQueueFactory
+    assert (
+        MockedDefaultFactoryCons.call_count == 2
+    )  # Called for `factory` and `factory_no_torch`
+
+    # Torch factory should not be called additionally if _TORCH_AVAILABLE is false
+    # Its call count should remain 1 (from the first factory instance when _TORCH_AVAILABLE was True)
+    assert MockedTorchFactoryCons.call_count == 1
+
+    dqf_module._TORCH_AVAILABLE = original_torch_available  # Restore
+    factory.shutdown()
+    factory_no_torch.shutdown()
+
+
+def test_factory_create_queues_returns_delegating_wrappers(
+    delegating_factory_instance: DelegatingMultiprocessQueueFactory[Any],
+) -> None:
+    sink, source = delegating_factory_instance.create_queues()
+    assert isinstance(sink, DelegatingMultiprocessQueueSink)
+    assert isinstance(source, DelegatingMultiprocessQueueSource)
+
+
+def test_factory_shutdown_calls_underlying_shutdowns(
+    mocker: MockerFixture,
+) -> None:
+    MockedDefaultFactoryCons = mocker.patch(
+        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
+    )
+    MockedTorchFactoryCons = mocker.patch(
+        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.TorchMultiprocessQueueFactory"
+    )
+
+    mock_default_factory_inst = MockedDefaultFactoryCons.return_value
+    mock_torch_factory_inst = MockedTorchFactoryCons.return_value
+
+    mock_default_factory_inst.create_queues.return_value = (
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+    )
+    mock_torch_factory_inst.create_queues.return_value = (
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+    )
+
+    original_torch_available = dqf_module._TORCH_AVAILABLE
+    dqf_module._TORCH_AVAILABLE = (
+        True  # Assume torch available for this test unit
+    )
+
+    factory = DelegatingMultiprocessQueueFactory[Any]()
+
+    mock_default_factory_inst.shutdown = mocker.MagicMock()
+    mock_torch_factory_inst.shutdown = mocker.MagicMock()
+
+    factory.shutdown()
+
+    mock_default_factory_inst.shutdown.assert_called_once()
+    if (
+        dqf_module._TORCH_AVAILABLE
+    ):  # Based on the mocked value during factory creation
+        mock_torch_factory_inst.shutdown.assert_called_once()
+
+    dqf_module._TORCH_AVAILABLE = original_torch_available
 
 
 @pytest.fixture
-def test_item() -> Any:
-    return "test_data"
+def mock_underlying_default_sink(
+    mocker: MockerFixture,
+) -> MultiprocessQueueSink[Any]:
+    return mocker.MagicMock(spec=MultiprocessQueueSink)
 
 
 @pytest.fixture
-def tensor_item_mock(mocker: MockerFixture) -> Optional[TensorType]:
-    if _torch_installed and torch_module:
-        return cast(TensorType, mocker.MagicMock(spec=torch_module.Tensor))
-    return None
+def mock_underlying_torch_sink(
+    mocker: MockerFixture,
+) -> Optional[MultiprocessQueueSink[Any]]:
+    if not _torch_installed:
+        return None
+    return mocker.MagicMock(spec=MultiprocessQueueSink)
 
 
 @pytest.fixture
 def delegating_sink(
-    mock_shared_dict: Any,
-    mock_shared_lock: Any,
-    mock_manager_instance: Any,
-    mock_is_torch_available: MockerFixture,
+    mock_underlying_default_sink: MultiprocessQueueSink[Any],
+    mock_underlying_torch_sink: Optional[MultiprocessQueueSink[Any]],
 ) -> DelegatingMultiprocessQueueSink[Any]:
     return DelegatingMultiprocessQueueSink[Any](
-        shared_manager_dict=mock_shared_dict,
-        shared_lock=mock_shared_lock,
-        manager_instance=mock_manager_instance,
+        default_sink=mock_underlying_default_sink,
+        torch_sink=mock_underlying_torch_sink,
     )
 
 
-def test_sink_init(
+def test_sink_put_default_item(
     delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    mock_shared_dict: Any,
-) -> None:
-    assert (
-        delegating_sink._DelegatingMultiprocessQueueSink__shared_dict
-        is mock_shared_dict
-    )
-    assert (
-        delegating_sink._DelegatingMultiprocessQueueSink__real_sink_internal
-        is None
-    )
-    assert not delegating_sink._DelegatingMultiprocessQueueSink__closed_flag
-
-
-@pytest.mark.skipif(not _torch_installed, reason="PyTorch not installed.")
-def test_initialize_real_sink_torch_path_if_torch_available(
+    mock_underlying_default_sink: MultiprocessQueueSink[Any],
+    mock_underlying_torch_sink: Optional[MultiprocessQueueSink[Any]],
+    default_item: Dict[str, Any],
     mocker: MockerFixture,
-    delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    mock_is_torch_available: MockerFixture,
-    mock_shared_dict: Any,
 ) -> None:
-    mock_is_torch_available.return_value = True
-    mock_shared_dict.get.return_value = False
+    mocker.patch.object(
+        dqf_module, "_TORCH_AVAILABLE", False
+    )  # Ensure default path chosen
 
-    assert (
-        torch_module is not None
-    ), "Torch module not available for torch path test"
-    mock_tensor_data = mocker.MagicMock(spec=torch_module.Tensor)
-    item_with_tensor_data = mocker.MagicMock()
-    item_with_tensor_data.data = mock_tensor_data
+    delegating_sink.put_nowait(default_item)
 
-    PatchedInternalSink = mocker.patch.object(
-        dqf_module, "MultiprocessQueueSink"
+    mock_underlying_default_sink.put_nowait.assert_any_call(
+        USE_DEFAULT_QUEUE_MSG
     )
-    PatchedInternalSource = mocker.patch.object(
-        dqf_module, "MultiprocessQueueSource"
-    )
+    mock_underlying_default_sink.put_nowait.assert_any_call(default_item)
 
-    mock_torch_factory_instance = mocker.MagicMock()
-    mock_torch_factory_instance.create_queues.return_value = (
-        mocker.MagicMock(spec=MultiprocessQueueSink),
-        mocker.MagicMock(spec=MultiprocessQueueSource),
-    )
+    if mock_underlying_torch_sink:
+        mock_underlying_torch_sink.put_nowait.assert_not_called()
 
-    MockedTorchFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.TorchMultiprocessQueueFactory"
-    )
-    MockedTorchFactory.return_value = mock_torch_factory_instance
-
-    MockedDefaultFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
+    another_default_item = {"data": "another"}
+    delegating_sink.put_nowait(another_default_item)
+    # Calls: 1 for USE_DEFAULT_QUEUE_MSG, 1 for default_item, 1 for another_default_item
+    assert mock_underlying_default_sink.put_nowait.call_count == 3
+    mock_underlying_default_sink.put_nowait.assert_any_call(
+        another_default_item
     )
 
-    delegating_sink._DelegatingMultiprocessQueueSink__initialize_real_sink(
-        item_with_tensor_data
+
+@pytest.mark.skipif(
+    not (_torch_installed and torch_module),
+    reason="PyTorch not installed/available.",
+)
+def test_sink_put_tensor_item(
+    delegating_sink: DelegatingMultiprocessQueueSink[Any],
+    mock_underlying_default_sink: MultiprocessQueueSink[Any],
+    mock_underlying_torch_sink: MultiprocessQueueSink[Any],
+    tensor_item: TensorType,
+    mocker: MockerFixture,
+) -> None:
+    assert mock_underlying_torch_sink is not None, (
+        "Torch sink mock should be present for this test"
     )
+    assert tensor_item is not None, "Tensor item fixture failed"
 
-    MockedTorchFactory.assert_called_once()
-    mock_torch_factory_instance.create_queues.assert_called_once()
-    MockedDefaultFactory.assert_not_called()
+    mocker.patch.object(dqf_module, "_TORCH_AVAILABLE", True)
+    mocker.patch.object(dqf_module, "_torch_tensor_type", torch_module.Tensor)
 
-    found_ref_call = False
-    for call_args_tuple in mock_shared_dict.__setitem__.call_args_list:
-        if call_args_tuple[0][0] == "real_queue_source_ref":
-            assert isinstance(call_args_tuple[0][1], mocker.MagicMock)
-            found_ref_call = True
+    delegating_sink.put_nowait(tensor_item)
+
+    mock_underlying_default_sink.put_nowait.assert_called_once_with(
+        USE_TORCH_QUEUE_MSG
+    )
+    mock_underlying_torch_sink.put_nowait.assert_called_once_with(tensor_item)
+
+    another_tensor = torch_module.tensor([4.0])  # type: ignore
+    delegating_sink.put_nowait(another_tensor)
+
+    # Check call with another_tensor manually due to tensor comparison issues with assert_any_call
+    found_another_tensor_call = False
+    for call_args in mock_underlying_torch_sink.put_nowait.call_args_list:
+        args, _ = call_args
+        if len(args) == 1 and torch_module.equal(args[0], another_tensor):
+            found_another_tensor_call = True
             break
-    assert found_ref_call, "real_queue_source_ref was not set as expected."
-
-    assert isinstance(
-        delegating_sink._DelegatingMultiprocessQueueSink__real_sink_internal,
-        mocker.MagicMock,
+    assert found_another_tensor_call, (
+        "put_nowait was not called with another_tensor"
     )
 
+    assert mock_underlying_torch_sink.put_nowait.call_count == 2
+    assert mock_underlying_default_sink.put_nowait.call_count == 1
 
-def test_initialize_real_sink_default_path_when_torch_available(
-    mocker: MockerFixture,
+
+def test_sink_put_blocking(
     delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    mock_is_torch_available: MockerFixture,
-    mock_shared_dict: Any,
-    test_item: Any,
-) -> None:
-    mock_is_torch_available.return_value = True
-    mock_shared_dict.get.return_value = False
-
-    mock_default_factory_instance = mocker.MagicMock()
-    mock_default_factory_instance.create_queues.return_value = (
-        mocker.MagicMock(spec=MultiprocessQueueSink),
-        mocker.MagicMock(spec=MultiprocessQueueSource),
-    )
-
-    MockedDefaultFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
-    )
-    MockedDefaultFactory.return_value = mock_default_factory_instance
-
-    MockedTorchFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.TorchMultiprocessQueueFactory"
-    )
-
-    delegating_sink._DelegatingMultiprocessQueueSink__initialize_real_sink(
-        test_item
-    )
-
-    MockedDefaultFactory.assert_called_once()
-    mock_default_factory_instance.create_queues.assert_called_once()
-    MockedTorchFactory.assert_not_called()
-
-
-def test_initialize_real_sink_default_path_when_torch_unavailable(
+    mock_underlying_default_sink: MultiprocessQueueSink[Any],
+    default_item: Dict[str, Any],
     mocker: MockerFixture,
-    delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    mock_is_torch_available: MockerFixture,
-    mock_shared_dict: Any,
-    test_item: Any,
 ) -> None:
-    mock_is_torch_available.return_value = False
-    mock_shared_dict.get.return_value = False
-
-    mock_default_factory_instance = mocker.MagicMock()
-    mock_default_factory_instance.create_queues.return_value = (
-        mocker.MagicMock(spec=MultiprocessQueueSink),
-        mocker.MagicMock(spec=MultiprocessQueueSource),
+    mocker.patch.object(dqf_module, "_TORCH_AVAILABLE", False)
+    delegating_sink.put_blocking(default_item, timeout=1.0)
+    mock_underlying_default_sink.put_blocking.assert_any_call(
+        default_item, timeout=1.0
+    )
+    mock_underlying_default_sink.put_nowait.assert_called_once_with(
+        USE_DEFAULT_QUEUE_MSG
     )
 
-    MockedDefaultFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
-    )
-    MockedDefaultFactory.return_value = mock_default_factory_instance
 
-    MockedTorchFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.TorchMultiprocessQueueFactory"
-    )
-
-    delegating_sink._DelegatingMultiprocessQueueSink__initialize_real_sink(
-        test_item
-    )
-
-    MockedDefaultFactory.assert_called_once()
-    mock_default_factory_instance.create_queues.assert_called_once()
-    MockedTorchFactory.assert_not_called()
-
-
-def test_initialize_real_sink_called_only_once(
-    mocker: MockerFixture,
-    delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    mock_is_torch_available: MockerFixture,
-    mock_shared_dict: Any,
-    test_item: Any,
-) -> None:
-    mock_is_torch_available.return_value = False
-    mock_shared_dict.get.side_effect = [
-        False,
-        True,
-        True,
-        True,
-    ]
-
-    mock_default_factory_instance = mocker.MagicMock()
-    mock_default_factory_instance.create_queues.return_value = (
-        mocker.MagicMock(spec=MultiprocessQueueSink),
-        mocker.MagicMock(spec=MultiprocessQueueSource),
-    )
-
-    MockedDefaultFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
-    )
-    MockedDefaultFactory.return_value = mock_default_factory_instance
-    delegating_sink._DelegatingMultiprocessQueueSink__initialize_real_sink(
-        test_item
-    )
-    MockedDefaultFactory.assert_called_once()
-    mock_default_factory_instance.create_queues.assert_called_once()
-
-    delegating_sink._DelegatingMultiprocessQueueSink__initialize_real_sink(
-        test_item
-    )
-    MockedDefaultFactory.assert_called_once()
-    mock_default_factory_instance.create_queues.assert_called_once()
-
-
-def test_put_blocking_and_put_nowait_delegation(
-    mocker: MockerFixture,
-    delegating_sink: DelegatingMultiprocessQueueSink[Any],
-    mock_is_torch_available: MockerFixture,
-    mock_shared_dict: Any,
-    test_item: Any,
-) -> None:
-    mock_is_torch_available.return_value = False
-    mock_shared_dict.get.return_value = False
-
-    mock_real_sink_instance = mocker.MagicMock(spec=MultiprocessQueueSink)
-    mock_default_factory_instance = mocker.MagicMock()
-    mock_default_factory_instance.create_queues.return_value = (
-        mock_real_sink_instance,
-        mocker.MagicMock(spec=MultiprocessQueueSource),
-    )
-
-    MockedDefaultFactory = mocker.patch(
-        "tsercom.threading.multiprocess.delegating_multiprocess_queue_factory.DefaultMultiprocessQueueFactory"
-    )
-    MockedDefaultFactory.return_value = mock_default_factory_instance
-    delegating_sink.put_nowait(test_item)
-
-    MockedDefaultFactory.assert_called_once()
-    mock_default_factory_instance.create_queues.assert_called_once()
-    assert (
-        delegating_sink._DelegatingMultiprocessQueueSink__real_sink_internal
-        is mock_real_sink_instance
-    )
-    mock_real_sink_instance.put_nowait.assert_called_once_with(test_item)
-
-    delegating_sink.put_blocking("item2", timeout=1.0)
-    mock_real_sink_instance.put_blocking.assert_called_once_with(
-        "item2", timeout=1.0
-    )
-
-    delegating_sink.put_nowait("item3")
-    assert mock_real_sink_instance.put_nowait.call_count == 2
-    mock_real_sink_instance.put_nowait.assert_called_with("item3")
-
-
-def test_put_when_closed_raises_runtime_error(
-    delegating_sink: DelegatingMultiprocessQueueSink[Any], test_item: Any
-) -> None:
-    delegating_sink.close()
-    with pytest.raises(RuntimeError, match="Sink closed"):
-        delegating_sink.put_blocking(test_item)
-    with pytest.raises(RuntimeError, match="Sink closed"):
-        delegating_sink.put_nowait(test_item)
-
-
-def test_properties_and_utility_methods_before_init(
+def test_sink_closed_property_and_method(
     delegating_sink: DelegatingMultiprocessQueueSink[Any],
 ) -> None:
     assert not delegating_sink.closed
-
-
-def test_properties_and_utility_methods_after_init(
-    mocker: MockerFixture,
-    delegating_sink: DelegatingMultiprocessQueueSink[Any],
-) -> None:
-    mock_underlying_mp_queue: Any = mocker.MagicMock()
-    mock_underlying_mp_queue.qsize.return_value = 5
-    mock_underlying_mp_queue.empty.return_value = False
-    mock_underlying_mp_queue.full.return_value = True
-    mock_real_sink_wrapper = mocker.MagicMock(spec=MultiprocessQueueSink)
-    setattr(
-        mock_real_sink_wrapper,
-        "_MultiprocessQueueSink__queue",
-        mock_underlying_mp_queue,
-    )
-
-    delegating_sink._DelegatingMultiprocessQueueSink__real_sink_internal = (
-        cast(MultiprocessQueueSink[Any], mock_real_sink_wrapper)
-    )
-    internal_queue = (
-        delegating_sink._DelegatingMultiprocessQueueSink__real_sink_internal._MultiprocessQueueSink__queue
-    )
-    assert internal_queue.qsize() == 5
-    assert not internal_queue.empty()
-    assert internal_queue.full()
     delegating_sink.close()
     assert delegating_sink.closed
+    with pytest.raises(RuntimeError, match="Sink closed"):
+        delegating_sink.put_nowait("item")
 
 
 @pytest.fixture
-def mock_real_mp_queue_source(mocker: MockerFixture) -> Any:
-    mock_source = mocker.MagicMock(spec=MultiprocessQueueSource)
-    mock_source._MultiprocessQueueSource__queue = mocker.MagicMock()
-    return mock_source
+def mock_underlying_default_source(
+    mocker: MockerFixture,
+) -> MultiprocessQueueSource[Any]:
+    return mocker.MagicMock(spec=MultiprocessQueueSource)
 
 
 @pytest.fixture
-def mock_time_sleep(mocker: MockerFixture) -> MockerFixture:
-    return mocker.patch("time.sleep", return_value=None)
+def mock_underlying_torch_source(
+    mocker: MockerFixture,
+) -> Optional[MultiprocessQueueSource[Any]]:
+    if not _torch_installed:
+        return None
+    return mocker.MagicMock(spec=MultiprocessQueueSource)
 
 
 @pytest.fixture
 def delegating_source(
-    mock_shared_dict: Any,
-    mock_shared_lock: Any,
-    mock_time_sleep: MockerFixture,
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+    mock_underlying_torch_source: Optional[MultiprocessQueueSource[Any]],
 ) -> DelegatingMultiprocessQueueSource[Any]:
     return DelegatingMultiprocessQueueSource[Any](
-        mock_shared_dict, mock_shared_lock
+        default_source=mock_underlying_default_source,
+        torch_source=mock_underlying_torch_source,
     )
 
 
-def test_source_init(
+def test_source_get_default_path(
     delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+    mock_underlying_torch_source: Optional[MultiprocessQueueSource[Any]],
+    default_item: Dict[str, Any],
 ) -> None:
+    another_item = "another_item_str"
+    mock_underlying_default_source.get_blocking.side_effect = [
+        USE_DEFAULT_QUEUE_MSG,  # For coordination
+        default_item,  # First actual item
+        another_item,  # Second actual item
+    ]
+
+    item1 = delegating_source.get_blocking(timeout=0.1)
+    assert item1 == default_item
+
+    # get_blocking calls: 1 for coord, 1 for item1
+    assert mock_underlying_default_source.get_blocking.call_count == 2
+    # Check that the first call was for coordination (timeout passed through)
+    # and the second call was for the data item (timeout passed through)
+    mock_underlying_default_source.get_blocking.assert_any_call(timeout=0.1)
+
+    item2 = delegating_source.get_blocking(timeout=0.1)
+    assert item2 == another_item
     assert (
-        delegating_source._DelegatingMultiprocessQueueSource__shared_dict
-        is mock_shared_dict
+        mock_underlying_default_source.get_blocking.call_count == 3
+    )  # Total calls
+
+    if mock_underlying_torch_source:
+        mock_underlying_torch_source.get_blocking.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not (_torch_installed and torch_module),
+    reason="PyTorch not installed/available.",
+)
+def test_source_get_tensor_path(
+    delegating_source: DelegatingMultiprocessQueueSource[Any],
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+    mock_underlying_torch_source: MultiprocessQueueSource[Any],
+    tensor_item: TensorType,
+) -> None:
+    assert mock_underlying_torch_source is not None
+    assert tensor_item is not None
+
+    another_tensor = torch_module.tensor([4.0])  # type: ignore
+
+    mock_underlying_default_source.get_blocking.return_value = (
+        USE_TORCH_QUEUE_MSG
     )
-    assert (
-        delegating_source._DelegatingMultiprocessQueueSource__real_source_internal
-        is None
+    mock_underlying_torch_source.get_blocking.side_effect = [
+        tensor_item,
+        another_tensor,
+    ]
+
+    item1 = delegating_source.get_blocking(timeout=0.1)
+    assert item1 is tensor_item
+
+    mock_underlying_default_source.get_blocking.assert_called_once_with(
+        timeout=0.1
     )
-
-
-def test_ensure_real_source_initialized_immediately(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-    mock_real_mp_queue_source: Any,
-) -> None:
-    mock_shared_dict.get.side_effect = lambda key, default=None: {
-        "initialized": True,
-        "real_queue_source_ref": mock_real_mp_queue_source,
-    }.get(key, default)
-    delegating_source._ensure_real_source_initialized(polling_timeout=0.01)
-    assert (
-        delegating_source._DelegatingMultiprocessQueueSource__real_source_internal
-        is mock_real_mp_queue_source
-    )
-
-
-def test_ensure_real_source_initialized_after_delay(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-    mock_real_mp_queue_source: Any,
-    mock_time_sleep: MockerFixture,
-) -> None:
-    results: List[bool] = [False, False, True]
-
-    def get_from_dict(key: str, default: Any = None) -> Any:
-        if key == "initialized":
-            return results.pop(0) if results else True
-        if key == "real_queue_source_ref":
-            return mock_real_mp_queue_source if not results else None
-        return default
-
-    mock_shared_dict.get.side_effect = get_from_dict
-    delegating_source._ensure_real_source_initialized(polling_timeout=0.1)
-    assert (
-        delegating_source._DelegatingMultiprocessQueueSource__real_source_internal
-        is mock_real_mp_queue_source
-    )
-    mock_time_sleep.assert_called()
-
-
-def test_ensure_real_source_initialized_timeout(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-) -> None:
-    mock_shared_dict.get.return_value = False
-    with pytest.raises(queue.Empty):
-        delegating_source._ensure_real_source_initialized(polling_timeout=0.03)
-
-
-def test_ensure_real_source_initialized_bad_ref_none(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-) -> None:
-    mock_shared_dict.get.side_effect = lambda k, d=None: {
-        "initialized": True,
-        "real_queue_source_ref": None,
-    }.get(k, d)
-    with pytest.raises(RuntimeError, match="missing"):
-        delegating_source._ensure_real_source_initialized(polling_timeout=0.01)
-
-
-def test_ensure_real_source_initialized_bad_ref_type(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-) -> None:
-    mock_shared_dict.get.side_effect = lambda k, d=None: {
-        "initialized": True,
-        "real_queue_source_ref": "bad",
-    }.get(k, d)
-    with pytest.raises(RuntimeError, match="Invalid"):
-        delegating_source._ensure_real_source_initialized(polling_timeout=0.01)
-
-
-def test_get_methods_delegation_after_init(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_real_mp_queue_source: Any,
-) -> None:
-    delegating_source._DelegatingMultiprocessQueueSource__real_source_internal = (
-        mock_real_mp_queue_source
-    )
-    val = "item"
-    mock_real_mp_queue_source.get_blocking.return_value = val
-    assert delegating_source.get_blocking(timeout=0.1) == val
-    mock_real_mp_queue_source.get_or_none.return_value = val
-    assert delegating_source.get_or_none() == val
-
-
-def test_get_methods_wait_for_init(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-    mock_real_mp_queue_source: Any,
-    mock_time_sleep: MockerFixture,
-) -> None:
-    results: List[bool] = [False, True]
-
-    def get_from_dict(key: str, default: Any = None) -> Any:
-        if key == "initialized":
-            return results.pop(0) if results else True
-        if key == "real_queue_source_ref":
-            return mock_real_mp_queue_source if not results else None
-        return default
-
-    mock_shared_dict.get.side_effect = get_from_dict
-    val = "item_delay"
-    mock_real_mp_queue_source.get_blocking.return_value = val
-    assert delegating_source.get_blocking(timeout=0.1) == val
-    mock_time_sleep.assert_called()
-
-
-def test_utility_methods_before_init(
-    delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_shared_dict: Any,
-) -> None:
-    assert (
-        delegating_source._DelegatingMultiprocessQueueSource__real_source_internal
-        is None
+    mock_underlying_torch_source.get_blocking.assert_called_once_with(
+        timeout=0.1
     )
 
-    def mock_get(key: str, default: Any = None) -> Any:
-        if key == dqf_module.INITIALIZED_KEY:
-            return False
-        if key == dqf_module.REAL_QUEUE_SOURCE_REF_KEY:
-            return None
-        return default
-
-    mock_shared_dict.get.side_effect = mock_get
-    assert delegating_source.get_or_none() is None
+    item2 = delegating_source.get_blocking(timeout=0.1)
+    assert item2 is another_tensor
+    assert mock_underlying_default_source.get_blocking.call_count == 1
+    assert mock_underlying_torch_source.get_blocking.call_count == 2
 
 
-def test_utility_methods_after_init(
+def test_source_get_or_none(
     delegating_source: DelegatingMultiprocessQueueSource[Any],
-    mock_real_mp_queue_source: Any,
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+    default_item: Dict[str, Any],
 ) -> None:
-    delegating_source._DelegatingMultiprocessQueueSource__real_source_internal = (
-        mock_real_mp_queue_source
+    # Simulate coordination message on default_source.get_blocking(timeout=0.001)
+    mock_underlying_default_source.get_blocking.return_value = (
+        USE_DEFAULT_QUEUE_MSG
     )
-    underlying_q_mock = (
-        delegating_source._DelegatingMultiprocessQueueSource__real_source_internal._MultiprocessQueueSource__queue
+    # Simulate actual data item on default_source.get_or_none()
+    mock_underlying_default_source.get_or_none.return_value = default_item
+
+    item = delegating_source.get_or_none()
+    assert item == default_item
+
+    mock_underlying_default_source.get_blocking.assert_called_once_with(
+        timeout=0.001
     )
-    underlying_q_mock.qsize.return_value = 3
-    underlying_q_mock.empty.return_value = False
-    underlying_q_mock.full.return_value = True
-    assert underlying_q_mock.qsize() == 3
-    assert not underlying_q_mock.empty()
-    assert underlying_q_mock.full()
+    mock_underlying_default_source.get_or_none.assert_called_once()
 
 
-# Fixture for multi-process tests ensuring factory shutdown
+def test_source_get_blocking_timeout_on_coordination(
+    delegating_source: DelegatingMultiprocessQueueSource[Any],
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+) -> None:
+    mock_underlying_default_source.get_blocking.side_effect = queue.Empty
+    item = delegating_source.get_blocking(timeout=0.01)
+    assert item is None  # Should return None if coordination times out
+    mock_underlying_default_source.get_blocking.assert_called_once_with(
+        timeout=0.01
+    )
+
+
+def test_source_get_blocking_timeout_on_data(
+    delegating_source: DelegatingMultiprocessQueueSource[Any],
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+) -> None:
+    # First call to get_blocking (coordination) is successful
+    # Second call to get_blocking (data) results in None (simulating timeout)
+    mock_underlying_default_source.get_blocking.side_effect = [
+        USE_DEFAULT_QUEUE_MSG,
+        None,
+    ]
+
+    item = delegating_source.get_blocking(timeout=0.01)
+    assert item is None
+
+    assert mock_underlying_default_source.get_blocking.call_count == 2
+    # First call for coord, second for data, both with the specified timeout
+    mock_underlying_default_source.get_blocking.assert_any_call(timeout=0.01)
+
+
+def test_source_invalid_coordination_message(
+    delegating_source: DelegatingMultiprocessQueueSource[Any],
+    mock_underlying_default_source: MultiprocessQueueSource[Any],
+) -> None:
+    mock_underlying_default_source.get_blocking.return_value = (
+        "INVALID_MESSAGE"
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="Invalid coordination message received: INVALID_MESSAGE",
+    ):
+        delegating_source.get_blocking(timeout=0.01)
+
+
 @pytest.fixture
-def delegating_mp_factory() -> Any:
+def mp_delegating_factory(
+    request,
+) -> Any:  # request is a built-in pytest fixture
+    # Attempt to set start_method based on marker or test name if needed,
+    # otherwise ensure it's suitable for most tests (e.g. 'fork' on linux, 'spawn' elsewhere or if specified)
+    # For simplicity, we'll often rely on tests calling set_torch_mp_start_method_if_needed themselves.
+
+    # Clean up previous contexts if any - this can be tricky
+    # One robust way is to ensure each test that uses multiprocessing runs in a way
+    # that it can define its context without interference.
+    # Pytest runs tests in the same process, so MP context is shared unless care is taken.
+
+    # A common pattern for MP tests is to have a fixture that sets the start method
+    # for the duration of the test, then restores it.
+    # However, `set_start_method` can often only be called once.
+
     factory = dqf_module.DelegatingMultiprocessQueueFactory[Any]()
     yield factory
-    print(f"Shutting down delegating_mp_factory {id(factory)}...")
-    factory.shutdown()
-    print(f"Finished shutting down delegating_mp_factory {id(factory)}.")
+    print(f"Shutting down mp_delegating_factory {id(factory)}...")
+    factory.shutdown()  # Essential to release manager resources
+    print(f"Finished shutting down mp_delegating_factory {id(factory)}.")
 
 
-# Helper function for the actual test logic, parameterized by start method
-def _execute_mp_correctness_logic(
-    start_method_to_try: str,
-    factory_fixture: dqf_module.DelegatingMultiprocessQueueFactory[Any],
-    item_to_send: Any,  # Can be Dict or Tensor
-    is_tensor_test: bool = False,
+def _mp_producer_worker(
+    sink_queue: DelegatingMultiprocessQueueSink[Any],
+    items_to_send: List[Any],
+    result_queue_mp: queue.Queue,
+    worker_id: int,
 ) -> None:
-    assert (
-        torch_mp_module is not None
-    )  # Should be guaranteed by skipif on calling test
+    try:
+        print(f"Producer {worker_id} starting, items: {len(items_to_send)}")
+        for i, item in enumerate(items_to_send):
+            print(f"Producer {worker_id} putting item {i}: {type(item)}")
+            put_success = sink_queue.put_blocking(
+                item, timeout=20
+            )  # Increased timeout
+            if not put_success:
+                result_queue_mp.put(
+                    f"producer_{worker_id}_put_failed_item_{i}"
+                )
+                return
+            print(f"Producer {worker_id} successfully put item {i}")
+        result_queue_mp.put(f"producer_{worker_id}_success")
+        print(f"Producer {worker_id} finished normally.")
+    except Exception as e:
+        import traceback
 
-    set_torch_mp_start_method_if_needed(method=start_method_to_try)
+        tb_str = traceback.format_exc()
+        result_queue_mp.put(
+            f"producer_{worker_id}_exception: {type(e).__name__}: {e}\n{tb_str}"
+        )
+        print(f"Producer {worker_id} CRASHED: {e}\n{tb_str}")
 
-    current_ctx = torch_mp_module.get_context()
-    producer_status_queue: "torch_mp_module.Queue[str]" = current_ctx.Queue()
-    consumer_data_queue: "torch_mp_module.Queue[Any]" = current_ctx.Queue()
 
-    sink_q: Any
-    source_q: Any
-    if is_tensor_test:
-        assert (
-            _torch_installed and torch_module is not None
-        )  # Ensure torch is available for TensorType
-        sink_q_tensor: DelegatingMultiprocessQueueSink[TensorType]
-        source_q_tensor: DelegatingMultiprocessQueueSource[TensorType]
-        sink_q_tensor, source_q_tensor = factory_fixture.create_queues()
-        sink_q, source_q = sink_q_tensor, source_q_tensor
-        worker_producer = _producer_worker_tensor
-        worker_consumer = _consumer_worker_tensor
-    else:
-        sink_q_dict: DelegatingMultiprocessQueueSink[Dict[str, Any]]
-        source_q_dict: DelegatingMultiprocessQueueSource[Dict[str, Any]]
-        sink_q_dict, source_q_dict = factory_fixture.create_queues()
-        sink_q, source_q = sink_q_dict, source_q_dict
-        worker_producer = _producer_worker_default
-        worker_consumer = _consumer_worker_default
-
-    producer_process = current_ctx.Process(
-        target=worker_producer,
-        args=(sink_q, item_to_send, producer_status_queue),
+def _mp_consumer_worker(
+    source_queue: DelegatingMultiprocessQueueSource[Any],
+    num_items_expected: int,
+    result_queue_mp: queue.Queue,
+    worker_id: int,
+) -> None:
+    received_items: List[Any] = []
+    print(
+        f"Consumer {worker_id} starting, expecting {num_items_expected} items."
     )
-    consumer_process = current_ctx.Process(
-        target=worker_consumer,
-        args=(source_q, consumer_data_queue),
+    try:
+        for i in range(num_items_expected):
+            print(f"Consumer {worker_id} getting item {i}...")
+            item = source_queue.get_blocking(timeout=25)  # Increased timeout
+            if item is None:
+                result_queue_mp.put(
+                    f"consumer_{worker_id}_get_timed_out_after_{len(received_items)}_items"
+                )
+                return
+            print(f"Consumer {worker_id} got item {i}: {type(item)}")
+            received_items.append(item)
+        result_queue_mp.put(received_items)
+        print(
+            f"Consumer {worker_id} finished normally after receiving {len(received_items)} items."
+        )
+    except Exception as e:
+        import traceback
+
+        tb_str = traceback.format_exc()
+        result_queue_mp.put(
+            f"consumer_{worker_id}_exception: {type(e).__name__}: {e}\n{tb_str}"
+        )
+        print(f"Consumer {worker_id} CRASHED: {e}\n{tb_str}")
+
+
+def _run_mp_test_logic(
+    mp_start_method: str,
+    # factory: DelegatingMultiprocessQueueFactory[Any], # Factory will be created inside
+    items_to_send: List[Any],
+    is_tensor_test: bool,
+    process_id_suffix: str = "",
+    mocker_fixture: Optional[
+        MockerFixture
+    ] = None,  # For tests needing to mock _TORCH_AVAILABLE
+    force_torch_unavailable: bool = False,
+) -> None:
+    # This is critical: set start method *before* creating any MP objects like Queues for results.
+    # `force=True` is important if other tests might have set it.
+    set_torch_mp_start_method_if_needed(mp_start_method, force=True)
+
+    # Corrected logic for setting PyTorch sharing strategy
+    if _torch_installed and hasattr(torch_mp_module, "set_sharing_strategy"):
+        desired_strategy = (
+            "file_system"  # Default for fork, and now for spawn too
+        )
+        # if mp_start_method == 'spawn':
+        #     desired_strategy = 'file_descriptor' # Keeping this commented
+        try:
+            current_strategy = torch_mp_module.get_sharing_strategy()
+            if current_strategy != desired_strategy:
+                torch_mp_module.set_sharing_strategy(desired_strategy)
+                print(
+                    f"INFO: Set PyTorch sharing strategy to '{desired_strategy}' for {mp_start_method} test: {process_id_suffix}"
+                )
+        except RuntimeError as e:  # pylint: disable=broad-except
+            print(
+                f"WARNING: Could not set PyTorch sharing strategy to '{desired_strategy}' for {mp_start_method} test {process_id_suffix}. Error: {e}"
+            )
+
+    # Get context *after* setting start method
+    ctx = get_mp_context()
+
+    original_torch_available_state = None
+    original_torch_tensor_type_state = None
+
+    if force_torch_unavailable and mocker_fixture:
+        # This path is specifically for test_factory_behavior_torch_unavailable_e2e
+        original_torch_available_state = dqf_module._TORCH_AVAILABLE
+        original_torch_tensor_type_state = dqf_module._torch_tensor_type
+        # We are not just mocking the global; we are ensuring the factory instance
+        # itself is created while the module-level _TORCH_AVAILABLE is False.
+        # This requires patching the module attribute before DelegatingMultiprocessQueueFactory is instantiated.
+        mocker_fixture.patch.object(dqf_module, "_TORCH_AVAILABLE", False)
+        mocker_fixture.patch.object(dqf_module, "_torch_tensor_type", None)
+
+    factory_to_test = dqf_module.DelegatingMultiprocessQueueFactory[Any]()
+
+    # These queues are for results/status from child processes back to the main test process.
+    # They must be created by the context derived *after* set_start_method.
+    producer_result_q_mp = ctx.Queue()
+    consumer_result_q_mp = ctx.Queue()
+
+    # These are the queues under test, created by the factory.
+    sink, source = factory_to_test.create_queues()
+
+    producer_process = ctx.Process(
+        target=_mp_producer_worker,
+        args=(
+            sink,
+            items_to_send,
+            producer_result_q_mp,
+            f"p{process_id_suffix}",
+        ),
+        name=f"TestProducer-{mp_start_method}-{process_id_suffix}",
+    )
+    consumer_process = ctx.Process(
+        target=_mp_consumer_worker,
+        args=(
+            source,
+            len(items_to_send),
+            consumer_result_q_mp,
+            f"c{process_id_suffix}",
+        ),
+        name=f"TestConsumer-{mp_start_method}-{process_id_suffix}",
     )
 
+    print(
+        f"Starting producer for {mp_start_method} test ({process_id_suffix})..."
+    )
     producer_process.start()
+    print(
+        f"Starting consumer for {mp_start_method} test ({process_id_suffix})..."
+    )
     consumer_process.start()
 
-    process_join_timeout = 25
-    producer_process.join(timeout=process_join_timeout)
-    consumer_process.join(timeout=process_join_timeout)
+    # Wait for producer to finish and check its status
+    # Timeout should be generous for MP tests.
+    join_timeout_producer = 35
+    join_timeout_consumer = (
+        40  # Consumer might wait longer if producer is slow
+    )
 
-    if producer_process.is_alive():  # pragma: no cover
+    print(f"Waiting for producer status ({process_id_suffix})...")
+    producer_status = producer_result_q_mp.get(timeout=join_timeout_producer)
+    assert producer_status == f"producer_p{process_id_suffix}_success", (
+        f"Producer failed for '{mp_start_method}' ({process_id_suffix}): {producer_status}"
+    )
+    print(f"Producer finished successfully ({process_id_suffix}).")
+
+    # Wait for consumer to finish and check its results
+    print(f"Waiting for consumer results ({process_id_suffix})...")
+    consumer_output = consumer_result_q_mp.get(
+        timeout=join_timeout_consumer
+    )  # Consumer might take longer
+
+    # Add detailed logging for consumer output type
+    print(
+        f"Consumer output type for '{mp_start_method}' ({process_id_suffix}): {type(consumer_output)}"
+    )
+    print(
+        f"Consumer output content for '{mp_start_method}' ({process_id_suffix}): {consumer_output}"
+    )
+
+    assert isinstance(consumer_output, list), (
+        f"Consumer failed or returned wrong type for '{mp_start_method}' ({process_id_suffix}): {consumer_output}"
+    )
+    print(
+        f"Consumer returned list of {len(consumer_output)} items ({process_id_suffix})."
+    )
+
+    received_items: List[Any] = cast(List[Any], consumer_output)
+    assert len(received_items) == len(items_to_send), (
+        f"Item count mismatch for '{mp_start_method}' ({process_id_suffix}): sent {len(items_to_send)}, got {len(received_items)}"
+    )
+
+    for i, (sent_item, received_item) in enumerate(
+        zip(items_to_send, received_items)
+    ):
+        if (
+            _torch_installed
+            and torch_module
+            and isinstance(sent_item, torch_module.Tensor)
+        ):
+            assert isinstance(received_item, torch_module.Tensor), (
+                f"Item {i} was expected to be a Tensor but received {type(received_item)} for '{mp_start_method}' ({process_id_suffix})"
+            )
+            assert torch_module.equal(sent_item, received_item), (
+                f"Item {i} (Tensor) mismatch for '{mp_start_method}' ({process_id_suffix}): Sent {sent_item}, Got {received_item}"
+            )
+        elif isinstance(sent_item, dict) and isinstance(received_item, dict):
+            assert sent_item == received_item, (
+                f"Item {i} (dict) mismatch for '{mp_start_method}' ({process_id_suffix}): Sent {sent_item}, Got {received_item}"
+            )
+        else:
+            # General comparison for other types (e.g. simple strings, numbers, or if one is Tensor and other not)
+            assert sent_item == received_item, (
+                f"Item {i} mismatch for '{mp_start_method}' ({process_id_suffix}): Sent {sent_item} (type {type(sent_item)}), Got {received_item} (type {type(received_item)})"
+            )
+
+    print(f"Joining producer process ({process_id_suffix})...")
+    producer_process.join(
+        timeout=10
+    )  # Should be quick as it already reported success
+    print(f"Joining consumer process ({process_id_suffix})...")
+    consumer_process.join(timeout=10)
+
+    if producer_process.is_alive():
         producer_process.terminate()
         producer_process.join()
         pytest.fail(
-            f"Producer process timed out with '{start_method_to_try}' method."
+            f"Producer process timed out post-completion for '{mp_start_method}' ({process_id_suffix})."
         )
-
-    if consumer_process.is_alive():  # pragma: no cover
+    if consumer_process.is_alive():
         consumer_process.terminate()
         consumer_process.join()
         pytest.fail(
-            f"Consumer process timed out with '{start_method_to_try}' method."
+            f"Consumer process timed out post-completion for '{mp_start_method}' ({process_id_suffix})."
         )
 
-    try:
-        producer_status = producer_status_queue.get(timeout=5)
-        assert (
-            producer_status == "put_successful"
-        ), f"Producer status with '{start_method_to_try}': {producer_status}"
-    except queue.Empty:  # pragma: no cover
-        pytest.fail(
-            f"Producer status queue was empty with '{start_method_to_try}' method."
-        )
+    factory_to_test.shutdown()  # Shutdown the factory created in this function
 
-    try:
-        received_item = consumer_data_queue.get(timeout=5)
+    if force_torch_unavailable and mocker_fixture:
+        # Restore the original state if it was changed
+        if original_torch_available_state is not None:
+            dqf_module._TORCH_AVAILABLE = original_torch_available_state
         if (
-            isinstance(received_item, str)
-            and "exception" in received_item.lower()
-        ):
-            pytest.fail(
-                f"Consumer reported exception with '{start_method_to_try}': {received_item}"
-            )
+            original_torch_tensor_type_state is not None
+        ):  # Should always be true if first is
+            dqf_module._torch_tensor_type = original_torch_tensor_type_state
+        # It's generally safer to restore via the mocker if that's how it was set for the test's scope
+        # but since we patched module-level, direct assignment is how we undo if not using mocker.stopall()
+        # For specific object patches, mocker.stopall() or context manager `with patch:` is better.
+        # Here, we are controlling the module state for the duration of this specific logic.
 
-        if is_tensor_test:
-            assert torch_module is not None and isinstance(
-                received_item, torch_module.Tensor
-            ), f"Received item is not a Tensor with '{start_method_to_try}': {type(received_item)}"
-            assert torch_module.equal(
-                received_item, item_to_send
-            ), f"Received tensor {received_item} does not match sent tensor {item_to_send} with '{start_method_to_try}'."
-        else:
-            assert isinstance(
-                received_item, dict
-            ), f"Received item is not a dict with '{start_method_to_try}': {type(received_item)}. Content: {received_item}"
-            assert (
-                received_item == item_to_send
-            ), f"Received item {received_item} does not match sent item {item_to_send} with '{start_method_to_try}'."
-    except queue.Empty:  # pragma: no cover
-        pytest.fail(
-            f"Consumer data queue was empty with '{start_method_to_try}' method."
-        )
-
-
-@pytest.mark.skipif(
-    not (
-        _torch_installed
-        and torch_mp_module
-        and hasattr(torch_mp_module, "get_all_start_methods")
-        and "fork" in torch_mp_module.get_all_start_methods()
-    ),
-    reason="Fork start method not available or PyTorch MP not installed.",
-)
-def test_multiprocess_correctness_fork_default_item(
-    delegating_mp_factory: dqf_module.DelegatingMultiprocessQueueFactory[Any],
-    mocker: MockerFixture,
-) -> None:
-    """Tests MP correctness with 'fork' start method for a default item."""
-    assert torch_mp_module is not None
-    original_start_method = torch_mp_module.get_start_method(allow_none=True)
-    print(f"Original MP start method: {original_start_method}")
-    item_to_send = {
-        "data": "test_value_fork",
-        "id": 456,
-        "timestamp": time.time(),
-    }
-    try:
-        _execute_mp_correctness_logic(
-            "fork", delegating_mp_factory, item_to_send, is_tensor_test=False
-        )
-    finally:
-        if (
-            original_start_method
-            and hasattr(torch_mp_module, "set_start_method")
-            and torch_mp_module.get_start_method(allow_none=True)
-            != original_start_method
-        ):
-            try:
-                print(f"Restoring MP start method to: {original_start_method}")
-                torch_mp_module.set_start_method(
-                    original_start_method, force=True
-                )
-            except RuntimeError as e:  # pragma: no cover
-                warnings.warn(
-                    UserWarning(
-                        f"Could not restore original mp start method '{original_start_method}': {e}"
-                    )
-                )
-
-
-@pytest.mark.skipif(
-    not (
-        _torch_installed
-        and torch_mp_module
-        and hasattr(torch_mp_module, "get_all_start_methods")
-        and "spawn" in torch_mp_module.get_all_start_methods()
-    ),
-    reason="Spawn start method not available or PyTorch MP not installed.",
-)
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason="Known pickling issue: DelegatingQueueSink's manager instance is not pickleable for spawn",
-)
-def test_multiprocess_correctness_spawn_default_item(
-    delegating_mp_factory: dqf_module.DelegatingMultiprocessQueueFactory[Any],
-    mocker: MockerFixture,
-) -> None:
-    """Tests MP correctness with 'spawn' start method for a default item (expected to fail pickling)."""
-    assert torch_mp_module is not None
-    original_start_method = torch_mp_module.get_start_method(allow_none=True)
-    print(f"Original MP start method: {original_start_method}")
-    item_to_send = {
-        "data": "test_value_spawn",
-        "id": 789,
-        "timestamp": time.time(),
-    }
-    try:
-        _execute_mp_correctness_logic(
-            "spawn", delegating_mp_factory, item_to_send, is_tensor_test=False
-        )
-    finally:
-        if (
-            original_start_method
-            and hasattr(torch_mp_module, "set_start_method")
-            and torch_mp_module.get_start_method(allow_none=True)
-            != original_start_method
-        ):
-            try:
-                print(f"Restoring MP start method to: {original_start_method}")
-                torch_mp_module.set_start_method(
-                    original_start_method, force=True
-                )
-            except RuntimeError as e:  # pragma: no cover
-                warnings.warn(
-                    UserWarning(
-                        f"Could not restore original mp start method '{original_start_method}': {e}"
-                    )
-                )
-
-
-# New tests for tensor items
-@pytest.mark.skipif(
-    not (
-        _torch_installed
-        and torch_mp_module
-        and hasattr(torch_mp_module, "get_all_start_methods")
-        and "fork" in torch_mp_module.get_all_start_methods()
-    ),
-    reason="Fork start method not available or PyTorch MP not installed.",
-)
-def test_multiprocess_correctness_fork_tensor_item(
-    delegating_mp_factory: dqf_module.DelegatingMultiprocessQueueFactory[Any],
-    mocker: MockerFixture,
-) -> None:
-    """Tests MP correctness with 'fork' start method for a tensor item."""
-    assert torch_module is not None and torch_mp_module is not None
-    original_start_method = torch_mp_module.get_start_method(allow_none=True)
     print(
-        f"Original MP start method for tensor fork test: {original_start_method}"
+        f"MP test logic completed for '{mp_start_method}' ({process_id_suffix})."
     )
-    item_to_send = torch_module.tensor([1.0, 2.0, 3.0])
-    try:
-        _execute_mp_correctness_logic(
-            "fork", delegating_mp_factory, item_to_send, is_tensor_test=True
-        )
-    finally:
-        if (
-            original_start_method
-            and hasattr(torch_mp_module, "set_start_method")
-            and torch_mp_module.get_start_method(allow_none=True)
-            != original_start_method
-        ):
-            try:
-                print(
-                    f"Restoring MP start method to: {original_start_method} (from tensor fork test)"
-                )
-                torch_mp_module.set_start_method(
-                    original_start_method, force=True
-                )
-            except RuntimeError as e:  # pragma: no cover
-                warnings.warn(
-                    UserWarning(
-                        f"Could not restore original mp start method '{original_start_method}' from tensor fork test: {e}"
-                    )
-                )
+
+
+# Determine if 'fork' and 'spawn' are available for MP tests
+_mp_methods = (
+    multiprocessing.get_all_start_methods()
+    if hasattr(multiprocessing, "get_all_start_methods")
+    else []
+)
+if not _mp_methods and multiprocessing.get_start_method(
+    allow_none=True
+):  # fallback for older python
+    _mp_methods = [multiprocessing.get_start_method(allow_none=True)]  # type: ignore
+
+_torch_mp_methods = []
+if (
+    _torch_installed
+    and torch_mp_module
+    and hasattr(torch_mp_module, "get_all_start_methods")
+):
+    _torch_mp_methods = torch_mp_module.get_all_start_methods()
+
+FORK_AVAILABLE = "fork" in _mp_methods or "fork" in _torch_mp_methods
+SPAWN_AVAILABLE = "spawn" in _mp_methods or "spawn" in _torch_mp_methods
+
+
+# --- "fork" start method tests ---
+@pytest.mark.skipif(not FORK_AVAILABLE, reason="Fork method not available.")
+def test_mp_correctness_fork_default_item_first(
+    default_item,
+):  # Removed mp_delegating_factory
+    items = [default_item, {"data": "data2_fork", "id": 2}]
+    _run_mp_test_logic(
+        "fork",
+        items,  # Pass 'items' positionally
+        is_tensor_test=False,
+        process_id_suffix="fork_def",
+    )
 
 
 @pytest.mark.skipif(
-    not (
-        _torch_installed
-        and torch_mp_module
-        and hasattr(torch_mp_module, "get_all_start_methods")
-        and "spawn" in torch_mp_module.get_all_start_methods()
-    ),
-    reason="Spawn start method not available or PyTorch MP not installed.",
+    not (FORK_AVAILABLE and _torch_installed and torch_module),
+    reason="Fork or PyTorch for tensor not available.",
 )
-@pytest.mark.xfail(
-    raises=TypeError,
-    strict=True,
-    reason="Known pickling issue with manager instance for spawn, expected for tensor path too",
-)
-def test_multiprocess_correctness_spawn_tensor_item(
-    delegating_mp_factory: dqf_module.DelegatingMultiprocessQueueFactory[Any],
-    mocker: MockerFixture,
-) -> None:
-    """Tests MP correctness with 'spawn' start method for a tensor item (expected to xfail pickling)."""
-    assert torch_module is not None and torch_mp_module is not None
-    original_start_method = torch_mp_module.get_start_method(allow_none=True)
-    print(
-        f"Original MP start method for tensor spawn test: {original_start_method}"
+def test_mp_correctness_fork_tensor_item_first(
+    tensor_item,
+):  # Removed mp_delegating_factory
+    assert tensor_item is not None, "Tensor item fixture failed for fork test"
+    items = [
+        tensor_item,
+        torch_module.tensor([9.9, 8.8], dtype=torch_module.float32),
+    ]  # type: ignore
+    _run_mp_test_logic(
+        "fork",
+        items,  # Pass 'items' positionally
+        is_tensor_test=True,
+        process_id_suffix="fork_tensor",
     )
-    item_to_send = torch_module.tensor([4.0, 5.0, 6.0])
-    try:
-        _execute_mp_correctness_logic(
-            "spawn", delegating_mp_factory, item_to_send, is_tensor_test=True
-        )
-    finally:
-        if (
-            original_start_method
-            and hasattr(torch_mp_module, "set_start_method")
-            and torch_mp_module.get_start_method(allow_none=True)
-            != original_start_method
-        ):
-            try:
-                print(
-                    f"Restoring MP start method to: {original_start_method} (from tensor spawn test)"
-                )
-                torch_mp_module.set_start_method(
-                    original_start_method, force=True
-                )
-            except RuntimeError as e:  # pragma: no cover
-                warnings.warn(
-                    UserWarning(
-                        f"Could not restore original mp start method '{original_start_method}' from tensor spawn test: {e}"
-                    )
-                )
 
 
-@pytest.mark.timeout(45)  # Increased timeout for race condition test
 @pytest.mark.skipif(
-    not (
-        _torch_installed
-        and torch_mp_module
-        and hasattr(torch_mp_module, "get_all_start_methods")
-        and "fork" in torch_mp_module.get_all_start_methods()
-    ),
-    reason="Fork start method not available or PyTorch MP not installed for race condition test.",
+    not (FORK_AVAILABLE and _torch_installed and torch_module),
+    reason="Fork or PyTorch for mixed test not available.",
 )
-def test_initialization_race_condition(
-    delegating_mp_factory: dqf_module.DelegatingMultiprocessQueueFactory[Any],
+def test_mp_correctness_fork_mixed_items_default_first(
+    default_item, tensor_item
+):  # Removed mp_delegating_factory
+    assert tensor_item is not None
+    items = [default_item, tensor_item]
+    _run_mp_test_logic(
+        "fork",
+        items,  # Pass 'items' positionally
+        is_tensor_test=False,
+        process_id_suffix="fork_mix_def",
+    )
+
+
+# --- "spawn" start method tests ---
+@pytest.mark.skipif(not SPAWN_AVAILABLE, reason="Spawn method not available.")
+def test_mp_correctness_spawn_default_item_first(
+    default_item,
+):  # Removed mp_delegating_factory
+    items = [default_item, {"data": "data_spawn", "id": 3}]
+    _run_mp_test_logic(
+        "spawn",
+        items,  # Pass 'items' positionally
+        is_tensor_test=False,
+        process_id_suffix="spawn_def",
+    )
+
+
+@pytest.mark.skipif(
+    not (SPAWN_AVAILABLE and _torch_installed and torch_module),
+    reason="Spawn or PyTorch for tensor not available.",
+)
+def test_mp_correctness_spawn_tensor_item_first(
+    tensor_item,
+):  # Removed mp_delegating_factory
+    assert tensor_item is not None
+    items = [
+        tensor_item,
+        torch_module.tensor([-1.0, -2.0], dtype=torch_module.float32),
+    ]  # type: ignore
+    _run_mp_test_logic(
+        "spawn",
+        items,  # Pass 'items' positionally
+        is_tensor_test=True,
+        process_id_suffix="spawn_tensor",
+    )
+
+
+@pytest.mark.skipif(
+    not (SPAWN_AVAILABLE and _torch_installed and torch_module),
+    reason="Spawn or PyTorch for mixed test not available.",
+)
+def test_mp_correctness_spawn_mixed_items_tensor_first(
+    tensor_item, default_item
+):  # Removed mp_delegating_factory
+    assert tensor_item is not None
+    items = [tensor_item, default_item]
+    _run_mp_test_logic(
+        "spawn",
+        items,  # Pass 'items' positionally
+        is_tensor_test=True,
+        process_id_suffix="spawn_mix_tensor",
+    )
+
+
+def test_factory_behavior_torch_unavailable_e2e(
     mocker: MockerFixture,
-) -> None:
-    """Tests race condition for queue initialization with multiple producers using 'fork'."""
-    assert torch_mp_module is not None  # Guaranteed by skipif
+    default_item,  # Removed mp_delegating_factory
+):
+    # This test ensures that even if torch was installed in the environment,
+    # if the factory *thinks* torch is unavailable (due to internal _TORCH_AVAILABLE flag),
+    # it correctly uses only the default path for an end-to-end MP scenario.
 
-    original_start_method = torch_mp_module.get_start_method(allow_none=True)
-    print(f"Original MP start method for race test: {original_start_method}")
-
-    try:
-        set_torch_mp_start_method_if_needed("fork")
-
-        # Get the manager from the factory to create shared resources directly
-        # This manager will be created within the 'fork' context established above.
-        manager = (
-            delegating_mp_factory._DelegatingMultiprocessQueueFactory__get_manager()
+    items_to_send = [default_item, {"type": "another_default", "value": 42}]
+    # Determine a start method that is likely to be available for this E2E test
+    # Prefer spawn if available, otherwise fork, as spawn is often more stringent.
+    current_start_method = "spawn" if SPAWN_AVAILABLE else "fork"
+    if (
+        not SPAWN_AVAILABLE and not FORK_AVAILABLE
+    ):  # Should not happen if tests run
+        pytest.skip(
+            "No suitable MP start method (spawn or fork) available for E2E test."
         )
-        assert (
-            manager is not None
-        ), "Manager should be initialized by the factory"
 
-        shared_lock = manager.Lock()
-        shared_dict = manager.dict()
-        shared_dict[dqf_module.INITIALIZED_KEY] = False
-        shared_dict[dqf_module.REAL_QUEUE_SOURCE_REF_KEY] = None
+    _run_mp_test_logic(
+        current_start_method,
+        items_to_send,  # Pass 'items_to_send' positionally
+        is_tensor_test=False,
+        process_id_suffix="notorch_e2e",
+        mocker_fixture=mocker,  # Pass the test's mocker
+        force_torch_unavailable=True,
+    )
+    # Old direct test logic removed as _run_mp_test_logic now covers it.
+    # The original_module_torch_available restoration is handled by _run_mp_test_logic
+    # original_module_torch_tensor_type = dqf_module._torch_tensor_type # This line is unused
 
-        num_producers = 3
-        # Barrier for num_producers + main thread (to signal consumer creation and start consumption)
-        barrier = torch_mp_module.Barrier(num_producers + 1)
-        producer_results_queue = torch_mp_module.Queue()
+    # Mock the module's view of torch availability
+    mocker.patch.object(dqf_module, "_TORCH_AVAILABLE", False)
+    mocker.patch.object(dqf_module, "_torch_tensor_type", None)
 
-        producers = []
-        sent_items = {}  # To store what each producer sent
+    # We need a new factory instance that is created *while* _TORCH_AVAILABLE is mocked as False.
+    # The mp_delegating_factory fixture might have already created its instance.
+    # So, we create one manually here for this specific test condition.
 
-        for i in range(num_producers):
-            item_to_send = f"race_item_producer_{i}"
-            sent_items[f"put_successful_producer_{i}"] = item_to_send
+    # Mock the factory constructors that DelegatingMultiprocessQueueFactory calls
+    # This mocking is now implicitly handled by _run_mp_test_logic if force_torch_unavailable is True
+    # We just need to ensure that the internal mocks in _run_mp_test_logic do not interfere with this.
+    # The current _run_mp_test_logic structure for force_torch_unavailable uses mocker.patch.object,
+    # which is fine.
+    pass  # Placeholder as the main logic is moved to _run_mp_test_logic
 
-            # Pass manager itself, and manager-created dict and lock to workers
-            # Workers will construct their own DelegatingMultiprocessQueueSink instances
-            p = torch_mp_module.Process(
-                target=_race_condition_producer_worker,
-                args=(
-                    manager,
-                    shared_dict,
-                    shared_lock,
-                    item_to_send,
-                    producer_results_queue,
-                    i,
-                    barrier,
-                ),
+
+# --- Minimal Test Case for torch.multiprocessing.Queue with 'spawn' ---
+
+
+def _minimal_producer_worker(
+    tmp_queue: Any,  # Should be torch.multiprocessing.Queue
+    tensor_to_send: TensorType,
+    result_q: Any,  # Standard ctx.Queue for status
+):
+    try:
+        print(f"[MinimalProducerMODIFIED] Original tensor: {tensor_to_send}")
+
+        # Ensure contiguity and then share memory
+        if not tensor_to_send.is_contiguous():
+            print(
+                "[MinimalProducerMODIFIED] Tensor not contiguous. Making it contiguous."
             )
-            producers.append(p)
-            p.start()
+            tensor_to_send = tensor_to_send.contiguous()
 
-        # Create the consumer-side queue object using the same shared resources
-        source_for_consumer = dqf_module.DelegatingMultiprocessQueueSource[
-            Any
-        ](shared_manager_dict=shared_dict, shared_lock=shared_lock)
-
+        print("[MinimalProducerMODIFIED] Calling share_memory_() on tensor.")
+        tensor_to_send.share_memory_()  # Explicitly share memory
         print(
-            "Main process waiting on barrier before consumers start getting..."
+            f"[MinimalProducerMODIFIED] Putting tensor after share_memory_(): {tensor_to_send}"
         )
-        barrier.wait(timeout=15)  # Unblock producers to start putting
+        tmp_queue.put(tensor_to_send)
+        print("[MinimalProducerMODIFIED] Tensor put successfully.")
+        result_q.put("producer_success")
+    except Exception as e:
+        import traceback
 
-        producer_success_count = 0
-        for _ in range(num_producers):
-            try:
-                status = producer_results_queue.get(timeout=15)
-                print(f"Producer result: {status}")
-                if status.startswith("put_successful_producer_"):
-                    producer_success_count += 1
-                else:  # pragma: no cover
-                    pytest.fail(f"A producer failed: {status}")
-            except queue.Empty:  # pragma: no cover
-                pytest.fail("Timeout waiting for producer results.")
+        tb_str = traceback.format_exc()
+        print(
+            f"[MinimalProducerMODIFIED] EXCEPTION: {e}\n{tb_str}"
+        )  # Python f-string will handle newline
+        result_q.put(f"producer_exception: {type(e).__name__}: {e}")
 
-        assert (
-            producer_success_count == num_producers
-        ), f"Expected {num_producers} successful producers, got {producer_success_count}"
 
-        received_items = set()
-        for _ in range(num_producers):
-            try:
-                item = source_for_consumer.get_blocking(timeout=15)
-                print(f"Consumer received: {item}")
-                received_items.add(item)
-            except queue.Empty:  # pragma: no cover
-                pytest.fail("Timeout waiting for consumer to receive item.")
+def _minimal_consumer_worker(
+    tmp_queue: Any,  # Should be torch.multiprocessing.Queue
+    result_q: Any,  # Standard ctx.Queue for received item or error
+):
+    try:
+        print("[MinimalConsumer] Getting tensor...")
+        received_tensor = tmp_queue.get(timeout=20)
+        print(f"[MinimalConsumer] Tensor received: {received_tensor}")
+        result_q.put(received_tensor)
+    except Exception as e:
+        import traceback
 
-        assert (
-            len(received_items) == num_producers
-        ), f"Expected to receive {num_producers} unique items, but got {len(received_items)}. Items: {received_items}"
+        tb_str = traceback.format_exc()
+        print(
+            f"[MinimalConsumer] EXCEPTION: {e}\n{tb_str}"
+        )  # Python f-string will handle newline
+        result_q.put(f"consumer_exception: {type(e).__name__}: {e}")
 
-        # Check if all sent items are part of the received items
-        for expected_item_val in sent_items.values():
-            assert (
-                expected_item_val in received_items
-            ), f"Expected item {expected_item_val} not found in received items {received_items}"
 
-        # Indirect check for initialization: The shared dict's INITIALIZED_KEY should be True
-        assert (
-            shared_dict.get(dqf_module.INITIALIZED_KEY) is True
-        ), "The shared INITIALIZED_KEY was not set to True after producers ran."
+@pytest.mark.skipif(
+    not (
+        SPAWN_AVAILABLE
+        and _torch_installed
+        and torch_module
+        and torch_mp_module
+    ),
+    reason="Spawn or PyTorch not available for minimal MP Queue test.",
+)
+def test_minimal_torch_mp_queue_spawn_tensor(tensor_item: TensorType):
+    """Tests torch.multiprocessing.Queue directly with 'spawn' and a tensor."""
+    assert tensor_item is not None, "Tensor item fixture failed"
+    assert torch_mp_module is not None, "torch_mp_module not available"
 
-    finally:
-        if (
-            original_start_method
-            and hasattr(torch_mp_module, "set_start_method")
-            and torch_mp_module.get_start_method(allow_none=True)
-            != original_start_method
-        ):
-            try:
-                print(
-                    f"Restoring MP start method to: {original_start_method} (from race test)"
-                )
-                torch_mp_module.set_start_method(
-                    original_start_method, force=True
-                )
-            except RuntimeError as e:  # pragma: no cover
-                warnings.warn(
-                    UserWarning(
-                        f"Could not restore original mp start method '{original_start_method}' from race test: {e}"
-                    )
-                )
+    print("\n--- Starting test_minimal_torch_mp_queue_spawn_tensor ---")
+
+    # Crucially, set start method to spawn BEFORE getting context or creating queues.
+    set_torch_mp_start_method_if_needed("spawn", force=True)
+
+    # Also explicitly set sharing strategy to file_system as it's often more robust
+    try:
+        current_strategy = torch_mp_module.get_sharing_strategy()
+        if current_strategy != "file_system":
+            torch_mp_module.set_sharing_strategy("file_system")
+            print(
+                f"INFO [MinimalTest]: Set PyTorch sharing strategy to 'file_system'. Was: {current_strategy}"
+            )
+        else:
+            print(
+                "INFO [MinimalTest]: PyTorch sharing strategy already 'file_system'."
+            )
+    except Exception as e:  # Broad except for safety in test setup
+        print(
+            f"WARNING [MinimalTest]: Could not set PyTorch sharing strategy to 'file_system': {e}"
+        )
+
+    ctx = torch_mp_module.get_context(
+        "spawn"
+    )  # Ensure spawn context from torch
+
+    torch_specific_queue = ctx.Queue()
+    producer_status_q = ctx.Queue()
+    consumer_data_q = ctx.Queue()
+
+    sent_tensor = tensor_item  # Use the fixture
+
+    producer_proc = ctx.Process(
+        target=_minimal_producer_worker,
+        args=(torch_specific_queue, sent_tensor, producer_status_q),
+    )
+    consumer_proc = ctx.Process(
+        target=_minimal_consumer_worker,
+        args=(torch_specific_queue, consumer_data_q),
+    )
+
+    print("[MinimalTest] Starting producer...")
+    producer_proc.start()
+    print("[MinimalTest] Starting consumer...")
+    consumer_proc.start()
+
+    producer_timeout = 30
+    consumer_timeout = 30
+
+    print("[MinimalTest] Waiting for producer status...")
+    producer_status = producer_status_q.get(timeout=producer_timeout)
+    assert producer_status == "producer_success", (
+        f"Minimal producer failed: {producer_status}"
+    )
+    print(f"[MinimalTest] Producer status: {producer_status}")
+
+    print("[MinimalTest] Waiting for consumer data...")
+    received_data = consumer_data_q.get(timeout=consumer_timeout)
+
+    assert isinstance(received_data, torch_module.Tensor), (
+        f"Minimal consumer received non-tensor data: {type(received_data)}, content: {received_data}"
+    )
+    print(f"[MinimalTest] Consumer received tensor: {received_data}")
+
+    assert torch_module.equal(sent_tensor, received_data), (
+        f"Minimal test tensor mismatch: Sent {sent_tensor}, Got {received_data}"
+    )
+
+    print("[MinimalTest] Joining producer...")
+    producer_proc.join(timeout=10)
+    print("[MinimalTest] Joining consumer...")
+    consumer_proc.join(timeout=10)
+
+    if producer_proc.is_alive():
+        producer_proc.terminate()
+        pytest.fail("Minimal producer process timed out post-completion.")
+    if consumer_proc.is_alive():
+        consumer_proc.terminate()
+        pytest.fail("Minimal consumer process timed out post-completion.")
+
+    print("--- Finished test_minimal_torch_mp_queue_spawn_tensor ---")

--- a/tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py
@@ -1,10 +1,14 @@
 """Defines a factory for creating torch.multiprocessing queues."""
 
+# Standard library imports
 from multiprocessing import Queue as MpQueue
-from typing import Tuple, TypeVar, Generic, Optional, cast
 from multiprocessing.managers import SyncManager
+from typing import Tuple, TypeVar, Generic, Optional, cast
+
+# Third-party imports
 import torch.multiprocessing as tmp
 
+# Project imports
 from tsercom.threading.multiprocess.multiprocess_queue_factory import (
     MultiprocessQueueFactory,
 )
@@ -34,25 +38,31 @@ class TorchMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
     def __init__(
         self,
         manager: Optional[SyncManager] = None,
-        ctx_method: str = "spawn",
+        # ctx_method: str = "spawn", # Removed to allow respecting global context
     ) -> None:
         """Initializes the TorchMultiprocessQueueFactory.
 
         Args:
             manager: An optional multiprocessing.Manager instance. If provided,
-                     its Queue() method will be used.
-            ctx_method: The multiprocessing context method to use if no manager
-                        is provided. Defaults to 'spawn'.
+                     its Queue() method will be used. If None,
+                     `torch.multiprocessing.get_context()` will be used,
+                     respecting the globally set start method.
         """
         super().__init__()
 
         self.__manager = manager
         if manager is None:
-            self.__mp_context = tmp.get_context(ctx_method)
+            # Use the current torch multiprocessing context, which should be
+            # set by set_torch_mp_start_method_if_needed before factory creation.
+            self.__mp_context = tmp.get_context()
         else:
-            self.__mp_context = None  # type: ignore
+            self.__mp_context = None # Manager will provide its own context for queues
 
-        assert (not self.__mp_context) != (not self.__manager)
+        # Ensure either manager or context is available, but not both if manager implies context
+        # If manager is provided, it's responsible for queue creation context.
+        # If manager is None, self.__mp_context must have been set.
+        assert bool(self.__manager) != bool(self.__mp_context), \
+            "Either a manager or an mp_context (derived from no manager) must be exclusively active."
 
     def create_queues(
         self,
@@ -69,7 +79,7 @@ class TorchMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
         """
         actual_queue: MpQueue[T]
         if self.__manager:
-            actual_queue = cast(MpQueue, self.__manager.Queue())
+            actual_queue = cast(MpQueue[T], self.__manager.Queue())
         elif self.__mp_context:
             actual_queue = self.__mp_context.Queue()
         else:
@@ -81,3 +91,27 @@ class TorchMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
         sink = MultiprocessQueueSink[T](actual_queue)
         source = MultiprocessQueueSource[T](actual_queue)
         return sink, source
+
+    def shutdown(self) -> None:
+        """
+        Shuts down the factory and any associated resources.
+        For this torch factory, if a manager was provided, it attempts to
+        shut down the manager. If a torch multiprocessing context was created,
+        it does not require explicit shutdown here as standard Python Queue
+        objects managed by a context don't have explicit individual shutdown methods.
+        The manager, if it owns the queue, is responsible for its lifecycle.
+        """
+        if self.__manager and hasattr(self.__manager, "shutdown"):
+            # Similar checks and error handling as in DefaultMultiprocessQueueFactory
+            try:
+                if (
+                    hasattr(self.__manager, "_process")
+                    and self.__manager._process is not None
+                    and self.__manager._process.is_alive()
+                ):
+                    self.__manager.shutdown()
+            except Exception:  # pylint: disable=broad-except
+                # Log or handle shutdown error
+                pass
+        # No specific shutdown needed for self.__mp_context.Queue() instances typically.
+        # The context itself doesn't have a public shutdown method in the same way a manager does.


### PR DESCRIPTION
This commit refactors `DelegatingMultiprocessQueueFactory` and its associated sink/source wrappers to address a `FileNotFoundError` that occurred when using the 'fork' multiprocessing start method with PyTorch tensors.

Key changes:
1.  **Eager Queue Creation:**
    *   `DelegatingMultiprocessQueueFactory` now eagerly creates two sets
        of underlying queues in its constructor (default and Torch-specific
        if PyTorch is available). This ensures queue resources are
        initialized in the parent process before forking.

2.  **Lazy Queue Selection:**
    *   `DelegatingMultiprocessQueueSink` and `Source` now use a
        coordination mechanism on the default queue. The first item's type
        determines if the Torch or default queue pair is used for actual
        data transfer for that and all subsequent items.

3.  **Unit Test Updates:**
    *   The test suite in `delegating_multiprocess_queue_factory_unittest.py`
        has been extensively updated.
    *   The 'fork' + tensor test (`test_mp_correctness_fork_tensor_item_first`)
        now passes.
    *   A new minimal test (`test_minimal_torch_mp_queue_spawn_tensor`)
        was added to help diagnose issues with 'spawn' and PyTorch tensors.

**Outcome:**
*   The primary goal of fixing the `FileNotFoundError` with the 'fork'
    start method and PyTorch tensors is **achieved**. All 'fork' method
    tests, including tensor scenarios, now pass.
*   'Spawn' method tests with non-tensor items also pass.

**Investigation of 'spawn' + PyTorch Tensor Failures:**
*   Extensive investigation was conducted into why tests using the 'spawn'
    start method with PyTorch Tensors fail with EOFError/FileNotFoundError
    (tests: `test_mp_correctness_spawn_tensor_item_first`,
    `test_mp_correctness_spawn_mixed_items_tensor_first`, and the
    diagnostic `test_minimal_torch_mp_queue_spawn_tensor`).
*   The minimal test, which uses `torch.multiprocessing.Queue` directly
    (bypassing all `tsercom` factory/wrapper logic), also fails under
    'spawn' with tensors.
*   Experiments included:
    *   Explicitly setting PyTorch's sharing strategy to 'file_system'.
    *   Explicitly calling `tensor.contiguous().share_memory_()` before
      putting tensors into the raw `torch.multiprocessing.Queue` in
      the minimal test.
*   None of these experiments resolved the failures in the minimal test
    case for 'spawn' + tensor.

**Conclusion on 'spawn' + PyTorch Tensor Issue:**
*   The persistent failures in the minimal `torch.multiprocessing.Queue`
    test strongly indicate that the root cause is external to the
    `tsercom.DelegatingMultiprocessQueueFactory` code. It is likely an
    underlying issue or limitation within PyTorch's `multiprocessing`
    module regarding tensor sharing with the 'spawn' start method in the
    current testing environment.
*   The `tsercom` code now correctly handles 'fork' scenarios and 'spawn'
    for non-tensor data. The `spawn`+tensor issue is documented via the
    failing minimal test included in the test suite.