### PR TITLE
Refactor queue factories and enhance torch IPC tests

### DIFF
--- a/tsercom/threading/multiprocess/default_multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/default_multiprocess_queue_factory.py
@@ -1,6 +1,6 @@
 """Defines the DefaultMultiprocessQueueFactory."""
 
-from multiprocessing import Queue as MpQueue
+import multiprocessing as std_mp  # Added for context and explicit queue type
 from typing import Tuple, TypeVar, Generic
 
 from tsercom.threading.multiprocess.multiprocess_queue_factory import (
@@ -26,17 +26,42 @@ class DefaultMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
     The `create_queue` method returns a raw `multiprocessing.Queue`.
     """
 
+    def __init__(
+        self,
+        ctx_method: str = "spawn",  # Defaulting to 'spawn'
+        context: std_mp.context.BaseContext | None = None,
+    ):
+        """Initializes the DefaultMultiprocessQueueFactory.
+
+        Args:
+            ctx_method: The multiprocessing context method to use if a specific
+                        `context` is not provided. Defaults to 'spawn'.
+                        Common options include 'fork', 'spawn', 'forkserver'.
+            context: An optional existing multiprocessing context (e.g., from
+                     `multiprocessing.get_context()`). If None, a new context
+                     is created using the specified `ctx_method`.
+        """
+        if context is not None:
+            self._mp_context: std_mp.context.BaseContext = context
+        else:
+            # Ensure std_mp is used here, not torch.multiprocessing
+            self._mp_context = std_mp.get_context(ctx_method)
+
     def create_queues(
         self,
     ) -> Tuple[MultiprocessQueueSink[T], MultiprocessQueueSource[T]]:
         """
-        Creates a pair of standard multiprocessing queues wrapped in Sink/Source.
+        Creates a pair of standard multiprocessing queues wrapped in Sink/Source,
+        using the configured multiprocessing context.
 
         Returns:
             A tuple containing MultiprocessQueueSink and MultiprocessQueueSource
-            instances, both using a standard `multiprocessing.Queue` internally.
+            instances, both using a context-aware `multiprocessing.Queue` internally.
         """
-        std_queue: MpQueue[T] = MpQueue()
+        # The type of queue created by self._mp_context.Queue() is typically
+        # multiprocessing.queues.Queue, not the alias MpQueue if it was from
+        # `from multiprocessing import Queue`.
+        std_queue: std_mp.queues.Queue[T] = self._mp_context.Queue()
         sink = MultiprocessQueueSink[T](std_queue)
         source = MultiprocessQueueSource[T](std_queue)
         return sink, source

--- a/tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py
@@ -1,5 +1,6 @@
 """Defines a factory for creating torch.multiprocessing queues."""
 
+import multiprocessing as std_mp  # For type hinting BaseContext
 from typing import Tuple, TypeVar, Generic
 import torch.multiprocessing as mp
 
@@ -29,15 +30,24 @@ class TorchMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
     `MultiprocessQueueSource` for interface consistency.
     """
 
-    def __init__(self, ctx_method: str = "spawn"):
+    def __init__(
+        self,
+        ctx_method: str = "spawn",
+        context: std_mp.context.BaseContext | None = None,
+    ):
         """Initializes the TorchMultiprocessQueueFactory.
 
         Args:
-            ctx_method: The multiprocessing context method to use.
-                        Defaults to 'spawn'. Other options include 'fork'
-                        and 'forkserver'.
+            ctx_method: The multiprocessing context method to use if context
+                        is not provided. Defaults to 'spawn'. Other options
+                        include 'fork' and 'forkserver'.
+            context: An optional existing multiprocessing context to use.
+                     If None, a new context is created using ctx_method.
         """
-        self._mp_context = mp.get_context(ctx_method)
+        if context is not None:
+            self._mp_context = context
+        else:
+            self._mp_context = mp.get_context(ctx_method)
 
     def create_queues(
         self,

--- a/tsercom/threading/multiprocess/torch_multiprocess_queue_factory_unittest.py
+++ b/tsercom/threading/multiprocess/torch_multiprocess_queue_factory_unittest.py
@@ -1,11 +1,12 @@
 """Unit tests for TorchMultiprocessQueueFactory."""
 
+import sys
+import time
 import pytest
 import torch
 import torch.multiprocessing as mp
 
-# TorchMpQueueType will now refer to torch.multiprocessing.Queue directly
-from typing import Type, Any, ClassVar
+from typing import Any, ClassVar, List
 
 from tsercom.threading.multiprocess.torch_multiprocess_queue_factory import (
     TorchMultiprocessQueueFactory,
@@ -18,21 +19,44 @@ from tsercom.threading.multiprocess.multiprocess_queue_source import (
 )
 
 
+def _top_level_consumer_process(
+    source_queue: MultiprocessQueueSource[torch.Tensor],
+    res_queue: "mp.Queue[Any]",
+) -> None:
+    for _ in range(TestTorchMultiprocessQueueFactory.NUM_ITEMS_TO_TRANSFER):
+        try:
+            tensor = source_queue.get_blocking(timeout=10)
+            if tensor is not None:
+                res_queue.put(tensor)
+            else:
+                res_queue.put("CONSUMER_GET_TIMEOUT")
+        except Exception as e:
+            try:
+                import pickle
+
+                pickle.dumps(e)
+                res_queue.put(e)
+            except Exception as final_put_e:
+                res_queue.put(
+                    f"CONSUMER_EXCEPTION_ON_GET_OR_PUT: {type(e).__name__} (Secondary: {type(final_put_e).__name__})"
+                )
+
+    # Child process is kept alive by this loop until terminated by the parent.
+    # This is crucial for ensuring queue integrity for some torch.multiprocessing versions/setups.
+    while True:
+        time.sleep(0.1)
+
+
 class TestTorchMultiprocessQueueFactory:
     """Tests for the TorchMultiprocessQueueFactory class."""
 
-    expected_torch_queue_type: ClassVar[
-        Type[mp.Queue]
-    ]  # Changed from TorchMpQueueType[Any]
+    NUM_ITEMS_TO_TRANSFER = 3
+    expected_torch_queue_type: ClassVar[type]
 
     @classmethod
-    def setup_class(
-        cls,
-    ) -> (
-        None
-    ):  # Pytest automatically calls methods named setup_class for class-level setup
+    def setup_class(cls) -> None:
         """Set up class method to get torch queue type once."""
-        # Torch multiprocessing queues require a specific context for creation.
+        # Torch multiprocessing queues may require a specific context for creation.
         ctx = mp.get_context("spawn")
         cls.expected_torch_queue_type = type(ctx.Queue())
 
@@ -49,12 +73,12 @@ class TestTorchMultiprocessQueueFactory:
         source: MultiprocessQueueSource[torch.Tensor]
         sink, source = factory.create_queues()
 
-        assert isinstance(
-            sink, MultiprocessQueueSink
-        ), "First item is not a MultiprocessQueueSink"
-        assert isinstance(
-            source, MultiprocessQueueSource
-        ), "Second item is not a MultiprocessQueueSource"
+        assert isinstance(sink, MultiprocessQueueSink), (
+            "First item is not a MultiprocessQueueSink"
+        )
+        assert isinstance(source, MultiprocessQueueSource), (
+            "Second item is not a MultiprocessQueueSource"
+        )
 
         # Internal queue type checks were removed due to fragility and MyPy errors with generics.
         # Correct functioning is tested by putting and getting data.
@@ -64,13 +88,114 @@ class TestTorchMultiprocessQueueFactory:
             put_successful = sink.put_blocking(tensor_to_send, timeout=1)
             assert put_successful, "sink.put_blocking failed"
             received_tensor = source.get_blocking(timeout=1)
-            assert (
-                received_tensor is not None
-            ), "source.get_blocking returned None (timeout)"
-            assert torch.equal(
-                tensor_to_send, received_tensor
-            ), "Tensor sent and received via Sink/Source are not equal."
+            assert received_tensor is not None, (
+                "source.get_blocking returned None (timeout)"
+            )
+            assert torch.equal(tensor_to_send, received_tensor), (
+                "Tensor sent and received via Sink/Source are not equal."
+            )
         except Exception as e:
             pytest.fail(
                 f"Tensor transfer via Sink/Source failed with exception: {e}"
             )
+
+    @pytest.mark.timeout(20)
+    @pytest.mark.parametrize("start_method", ["fork", "spawn", "forkserver"])
+    def test_interprocess_tensor_transfer_with_context(
+        self, start_method: str
+    ) -> None:
+        """
+        Tests tensor transfer between processes using different multiprocessing start methods.
+        """
+        if start_method == "forkserver" and sys.platform != "linux":
+            pytest.skip(
+                "forkserver start method is only reliably available on Linux"
+            )
+
+        mp_context = mp.get_context(start_method)
+        factory = TorchMultiprocessQueueFactory[torch.Tensor](
+            context=mp_context
+        )
+        sink, source = factory.create_queues()
+        result_queue: "mp.Queue[Any]" = mp_context.Queue()
+
+        process = mp_context.Process(  # type: ignore [attr-defined]
+            target=_top_level_consumer_process,
+            args=(source, result_queue),
+        )
+        process.daemon = (
+            True  # Ensures process is terminated if parent exits uncleanly.
+        )
+
+        sent_tensors: List[torch.Tensor] = []
+        received_items: List[Any] = []
+        process_started_successfully = False
+
+        try:
+            process.start()
+            process_started_successfully = True
+
+            for i in range(self.NUM_ITEMS_TO_TRANSFER):
+                original_tensor = torch.randn(4, 5)
+                # Add some variation for easier identification if debugging.
+                original_tensor[0, 0] = float(i + 1)
+                put_success = sink.put_blocking(original_tensor, timeout=5)
+                assert put_success, (
+                    f"Failed to put tensor {i + 1} onto the sink queue"
+                )
+                sent_tensors.append(original_tensor)
+
+            # Increased timeout per item for receive loop, overall test timeout is 20s.
+            for _ in range(self.NUM_ITEMS_TO_TRANSFER):
+                retrieved_item = result_queue.get(timeout=15)
+                received_items.append(retrieved_item)
+
+            assert len(received_items) == self.NUM_ITEMS_TO_TRANSFER, (
+                f"Expected {self.NUM_ITEMS_TO_TRANSFER} items, got {len(received_items)}"
+            )
+
+            for i in range(self.NUM_ITEMS_TO_TRANSFER):
+                sent_tensor = sent_tensors[i]
+                received_tensor = received_items[i]
+                assert isinstance(received_tensor, torch.Tensor), (
+                    f"Item {i} is not a Tensor. Got: {type(received_tensor)}, Value: {received_tensor}"
+                )
+                assert torch.equal(sent_tensor, received_tensor), (
+                    f"Tensor {i} sent and received are not equal."
+                )
+
+        finally:
+            if process_started_successfully and process.is_alive():
+                process.terminate()  # Send SIGTERM.
+                # Join should be called after terminate to wait for process resources to be cleaned up.
+                process.join(timeout=10)
+
+            if process_started_successfully and process.is_alive():
+                print(
+                    f"Warning: Child process {getattr(process, 'pid', 'unknown')} did not terminate cleanly after terminate() and join(). Attempting kill()."
+                )
+                if hasattr(process, "kill"):  # Available from Python 3.7+
+                    process.kill()
+                else:
+                    import os  # Keep imports local to where they are needed
+                    import signal
+
+                    try:
+                        if (
+                            process.pid is not None
+                        ):  # Check if pid is available
+                            os.kill(process.pid, signal.SIGKILL)
+                    except (
+                        ProcessLookupError
+                    ):  # Process might have already died.
+                        pass
+                process.join(timeout=5)
+
+            if process_started_successfully and process.is_alive():
+                pytest.fail(
+                    f"Child process {getattr(process, 'pid', 'unknown')} could not be terminated."
+                )
+            elif not process_started_successfully and process.is_alive():
+                # This case should ideally not be reached if process.start() failed and raised.
+                process.terminate()
+                process.join(timeout=1)

--- a/tsercom/threading/multiprocess/torch_multiprocess_queue_factory_unittest.py
+++ b/tsercom/threading/multiprocess/torch_multiprocess_queue_factory_unittest.py
@@ -73,12 +73,12 @@ class TestTorchMultiprocessQueueFactory:
         source: MultiprocessQueueSource[torch.Tensor]
         sink, source = factory.create_queues()
 
-        assert isinstance(sink, MultiprocessQueueSink), (
-            "First item is not a MultiprocessQueueSink"
-        )
-        assert isinstance(source, MultiprocessQueueSource), (
-            "Second item is not a MultiprocessQueueSource"
-        )
+        assert isinstance(
+            sink, MultiprocessQueueSink
+        ), "First item is not a MultiprocessQueueSink"
+        assert isinstance(
+            source, MultiprocessQueueSource
+        ), "Second item is not a MultiprocessQueueSource"
 
         # Internal queue type checks were removed due to fragility and MyPy errors with generics.
         # Correct functioning is tested by putting and getting data.
@@ -88,12 +88,12 @@ class TestTorchMultiprocessQueueFactory:
             put_successful = sink.put_blocking(tensor_to_send, timeout=1)
             assert put_successful, "sink.put_blocking failed"
             received_tensor = source.get_blocking(timeout=1)
-            assert received_tensor is not None, (
-                "source.get_blocking returned None (timeout)"
-            )
-            assert torch.equal(tensor_to_send, received_tensor), (
-                "Tensor sent and received via Sink/Source are not equal."
-            )
+            assert (
+                received_tensor is not None
+            ), "source.get_blocking returned None (timeout)"
+            assert torch.equal(
+                tensor_to_send, received_tensor
+            ), "Tensor sent and received via Sink/Source are not equal."
         except Exception as e:
             pytest.fail(
                 f"Tensor transfer via Sink/Source failed with exception: {e}"
@@ -140,9 +140,9 @@ class TestTorchMultiprocessQueueFactory:
                 # Add some variation for easier identification if debugging.
                 original_tensor[0, 0] = float(i + 1)
                 put_success = sink.put_blocking(original_tensor, timeout=5)
-                assert put_success, (
-                    f"Failed to put tensor {i + 1} onto the sink queue"
-                )
+                assert (
+                    put_success
+                ), f"Failed to put tensor {i + 1} onto the sink queue"
                 sent_tensors.append(original_tensor)
 
             # Increased timeout per item for receive loop, overall test timeout is 20s.
@@ -150,19 +150,19 @@ class TestTorchMultiprocessQueueFactory:
                 retrieved_item = result_queue.get(timeout=15)
                 received_items.append(retrieved_item)
 
-            assert len(received_items) == self.NUM_ITEMS_TO_TRANSFER, (
-                f"Expected {self.NUM_ITEMS_TO_TRANSFER} items, got {len(received_items)}"
-            )
+            assert (
+                len(received_items) == self.NUM_ITEMS_TO_TRANSFER
+            ), f"Expected {self.NUM_ITEMS_TO_TRANSFER} items, got {len(received_items)}"
 
             for i in range(self.NUM_ITEMS_TO_TRANSFER):
                 sent_tensor = sent_tensors[i]
                 received_tensor = received_items[i]
-                assert isinstance(received_tensor, torch.Tensor), (
-                    f"Item {i} is not a Tensor. Got: {type(received_tensor)}, Value: {received_tensor}"
-                )
-                assert torch.equal(sent_tensor, received_tensor), (
-                    f"Tensor {i} sent and received are not equal."
-                )
+                assert isinstance(
+                    received_tensor, torch.Tensor
+                ), f"Item {i} is not a Tensor. Got: {type(received_tensor)}, Value: {received_tensor}"
+                assert torch.equal(
+                    sent_tensor, received_tensor
+                ), f"Tensor {i} sent and received are not equal."
 
         finally:
             if process_started_successfully and process.is_alive():


### PR DESCRIPTION
This commit incorporates several improvements:

1.  **Consistent Context Handling for Queue Factories:**
    - `DefaultMultiprocessQueueFactory` has been updated to accept an optional `context` object and `ctx_method` string in its constructor, mirroring the behavior of `TorchMultiprocessQueueFactory`. This allows for consistent multiprocessing context management across different queue types, enabling applications to ensure specific start methods (e.g., 'spawn', 'fork') are used throughout.

2.  **Robust Multi-Item Tensor Transfer Test:**
    - `test_interprocess_tensor_transfer_with_context` in `torch_multiprocess_queue_factory_unittest.py` has been enhanced: - It now tests the transfer of multiple `torch.Tensor` objects sequentially. - The child process in the test is kept alive using an infinite loop after processing items and is explicitly terminated by the parent. This strategy robustly ensures sender liveness, which was found to be critical for reliable tensor transfer over `torch.multiprocessing.Queue`, and replaces previous event-based synchronization in the test. - The test now passes consistently for all parameterized start methods.

3.  **Code Cleanup:**
    - Removed unnecessary and meta-comments from `torch_multiprocess_queue_factory_unittest.py` to improve code clarity and adherence to commenting standards.

These changes make the multiprocessing queue factories more flexible and consistent, and provide a more comprehensive and reliable test for inter-process `torch.Tensor` communication.