### PR TITLE
Fix PicklingError in torch_memcpy_queue_factory and resolve mypy errors

### DIFF
--- a/tsercom/data/remote_data_organizer.py
+++ b/tsercom/data/remote_data_organizer.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy  # ADDED
 from functools import partial
 from typing import Generic, Optional, TypeVar
-from sortedcontainers import SortedList
+from sortedcontainers import SortedList  # type: ignore
 from tsercom.caller_id.caller_identifier import CallerIdentifier
 from tsercom.data.data_timeout_tracker import DataTimeoutTracker
 from tsercom.data.exposed_data import ExposedData

--- a/tsercom/threading/multiprocess/torch_memcpy_queue_factory.py
+++ b/tsercom/threading/multiprocess/torch_memcpy_queue_factory.py
@@ -24,7 +24,7 @@ from tsercom.threading.multiprocess.multiprocess_queue_source import (
     MultiprocessQueueSource,
 )
 
-QueueElementT = TypeVar("T")
+QueueElementT = TypeVar("QueueElementT")
 
 
 class TorchMemcpyQueueFactory(
@@ -160,7 +160,7 @@ class TorchMemcpyQueueSource(
                         if isinstance(
                             tensor_item, torch.Tensor
                         ):  # Double check for safety
-                            tensor_item.share_memory_()
+                            tensor_item.share_memory_()  # type: ignore[no-untyped-call]
                 except Exception as e:  # pylint: disable=broad-except
                     # Log warning if accessor fails, but return the item as is.
                     print(
@@ -168,7 +168,7 @@ class TorchMemcpyQueueSource(
                     )
             elif isinstance(item, torch.Tensor):
                 # Default behavior if no accessor: try to share if item is a tensor.
-                item.share_memory_()
+                item.share_memory_()  # type: ignore[no-untyped-call]
         return item
 
 
@@ -233,7 +233,7 @@ class TorchMemcpyQueueSink(
                     # but good for safety if accessor's contract is loose.
                     # The provided snippet has it, so keeping it.
                     if isinstance(tensor_item, torch.Tensor):
-                        tensor_item.share_memory_()
+                        tensor_item.share_memory_()  # type: ignore[no-untyped-call]
             except Exception as e:  # pylint: disable=broad-except
                 # Log a warning if the accessor fails, but still try to put the original object.
                 # The user of the queue might intend for non-tensor data or non-shareable tensors to pass.
@@ -242,6 +242,6 @@ class TorchMemcpyQueueSink(
                 )
         elif isinstance(obj, torch.Tensor):
             # Default behavior if no accessor: try to share if obj is a tensor.
-            obj.share_memory_()
+            obj.share_memory_()  # type: ignore[no-untyped-call]
 
         return super().put_blocking(obj, timeout=timeout)


### PR DESCRIPTION
This commit addresses a `_pickle.PicklingError` that occurred in `tsercom/threading/multiprocess/torch_memcpy_queue_factory_unittest.py` when using 'spawn' or 'forkserver' multiprocessing start methods. The error was resolved by renaming the `TypeVar` "T" to "QueueElementT" in `tsercom/threading/multiprocess/torch_memcpy_queue_factory.py`.

Additionally, `mypy` errors were resolved by:
- Adding `# type: ignore[no-untyped-call]` to calls to the untyped `share_memory_()` method in `torch_memcpy_queue_factory.py`.
- Adding `# type: ignore` to the import of `sortedcontainers` in `tsercom/data/remote_data_organizer.py` due to the unavailability of type stubs for this library.

All project tests pass (900 passed, 4 skipped) with `pytest --timeout=120` after these changes, confirmed by two consecutive runs. Static analysis checks (black, ruff, mypy) also pass for the modified files and relevant application code.