### PR TITLE
feat: Add local pre-commit framework with black and ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+-   repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+    -   id: black
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script sets up the development environment.
+set -e # Exit immediately if a command exits with a non-zero status.
+
+echo "--- Installing dependencies from pyproject.toml (including dev tools) ---"
+pip install -e .[dev]
+
+echo "--- Installing pre-commit git hooks ---"
+pre-commit install
+
+echo "--- Development environment setup is complete! You can now commit your changes. ---"


### PR DESCRIPTION
This commit introduces a local pre-commit framework to automatically format and lint Python code using `black` and `ruff` before each commit.

Key changes:
- I verified that `pre-commit` is included in the `[project.optional-dependencies].dev` section of `pyproject.toml`.
- I created a `.pre-commit-config.yaml` file in the repository root, configuring hooks for:
    - `pre-commit-hooks` (trailing-whitespace, end-of-file-fixer, check-yaml)
    - `black` for code formatting
    - `ruff` for linting, with `--fix` and `--exit-non-zero-on-fix` enabled for auto-correction.
- I created a `setup_dev.sh` script in the repository root to simplify the one-time setup for you. This script:
    - Installs all project dependencies, including development tools.
    - Installs the pre-commit git hooks.
    - The script is executable.

This setup ensures that code contributions are consistently formatted and linted, improving overall code quality and reducing the likelihood of CI failures related to style or linting issues.

I verified the changes by:
- Static analysis of the new/modified configuration files.
- Running the full test suite twice, with all tests passing.