### PR TITLE
feat: Implement gRPC Health Checking for Tsercom

### DIFF
--- a/tsercom/full_app_e2etest.py
+++ b/tsercom/full_app_e2etest.py
@@ -26,7 +26,7 @@ from tsercom.discovery.mdns.instance_listener import MdnsListenerFactory
 from tsercom.discovery.mdns.instance_publisher import InstancePublisher
 from tsercom.discovery.service_connector import ServiceConnector
 from tsercom.discovery.service_info import ServiceInfo
-from tsercom.rpc.common.channel_info import ChannelInfo
+from tsercom.rpc.common.channel_info import GrpcChannelInfo # Renamed
 from tsercom.rpc.grpc_util.grpc_channel_factory import GrpcChannelFactory
 from tsercom.rpc.grpc_util.grpc_service_publisher import GrpcServicePublisher
 from tsercom.runtime.runtime import Runtime
@@ -196,7 +196,7 @@ class GenericServerRuntime(
         self,
         connection_info: ServiceInfo,
         caller_id: CallerIdentifier,
-        channel_info: ChannelInfo,
+        channel_info: GrpcChannelInfo, # Renamed
     ):
         has_been_hit.set(True)
 

--- a/tsercom/rpc/common/channel_info.py
+++ b/tsercom/rpc/common/channel_info.py
@@ -1,12 +1,21 @@
 import dataclasses
 
 import grpc
+from tsercom.rpc.grpc_util.grpc_service_publisher import check_grpc_channel_health
 
 
 @dataclasses.dataclass
-class ChannelInfo:
+class GrpcChannelInfo:
     """Encapsulates information about a gRPC channel and its connection endpoint."""
 
-    channel: grpc.Channel
+    channel: grpc.aio.Channel
     address: str
     port: int
+
+    async def is_healthy(self) -> bool:
+        """Checks if the underlying gRPC channel is healthy.
+
+        Returns:
+            True if the channel is healthy (serving), False otherwise.
+        """
+        return await check_grpc_channel_health(self.channel)

--- a/tsercom/rpc/common/channel_info.py.bak
+++ b/tsercom/rpc/common/channel_info.py.bak
@@ -1,0 +1,12 @@
+import dataclasses
+
+import grpc
+
+
+@dataclasses.dataclass
+class ChannelInfo:
+    """Encapsulates information about a gRPC channel and its connection endpoint."""
+
+    channel: grpc.Channel
+    address: str
+    port: int

--- a/tsercom/rpc/common/channel_info.py.step2.bak
+++ b/tsercom/rpc/common/channel_info.py.step2.bak
@@ -1,0 +1,12 @@
+import dataclasses
+
+import grpc
+
+
+@dataclasses.dataclass
+class GrpcChannelInfo:
+    """Encapsulates information about a gRPC channel and its connection endpoint."""
+
+    channel: grpc.Channel
+    address: str
+    port: int

--- a/tsercom/rpc/common/channel_info.py.step3.bak
+++ b/tsercom/rpc/common/channel_info.py.step3.bak
@@ -1,0 +1,12 @@
+import dataclasses
+
+import grpc
+
+
+@dataclasses.dataclass
+class GrpcChannelInfo:
+    """Encapsulates information about a gRPC channel and its connection endpoint."""
+
+    channel: grpc.aio.Channel
+    address: str
+    port: int

--- a/tsercom/rpc/connection/__init__.py
+++ b/tsercom/rpc/connection/__init__.py
@@ -1,4 +1,4 @@
-from tsercom.rpc.common.channel_info import ChannelInfo
+from tsercom.rpc.common.channel_info import GrpcChannelInfo # Renamed
 from tsercom.rpc.connection.client_disconnection_retrier import (
     ClientDisconnectionRetrier,
 )
@@ -7,7 +7,7 @@ from tsercom.rpc.connection.client_reconnection_handler import (
 )
 
 __all__ = [
-    "ChannelInfo",
+    "GrpcChannelInfo", # Renamed
     "ClientDisconnectionRetrier",
     "ClientReconnectionManager",
 ]

--- a/tsercom/rpc/grpc_util/grpc_service_publisher_unittest.py
+++ b/tsercom/rpc/grpc_util/grpc_service_publisher_unittest.py
@@ -1,7 +1,15 @@
 import asyncio
 import threading
+from typing import AsyncIterator, Tuple
+
 import pytest
+import pytest_asyncio  # Added for async fixture
 import grpc
+from grpc_health.v1 import health_pb2  # type: ignore
+from tsercom.rpc.common.channel_info import GrpcChannelInfo
+from tsercom.rpc.grpc_util.transport.insecure_grpc_channel_factory import (
+    InsecureGrpcChannelFactory,
+)
 
 from tsercom.rpc.grpc_util.grpc_service_publisher import GrpcServicePublisher
 from tsercom.threading.thread_watcher import (
@@ -10,14 +18,14 @@ from tsercom.threading.thread_watcher import (
 
 
 # Dummy connect callback for GrpcServicePublisher
-def dummy_connect_callback(server: grpc.aio.Server):
+def dummy_connect_callback(server: grpc.aio.Server) -> None:
     """A placeholder callback for test purposes."""
     # In a real scenario, this would add servicers to the server.
     pass
 
 
 @pytest.mark.timeout(10)  # Set a timeout on the test itself to detect the hang
-def test_grpc_service_publisher_does_not_hang_in_threaded_loop():
+def test_grpc_service_publisher_does_not_hang_in_threaded_loop() -> None:
     """
     Tests that GrpcServicePublisher.start_async() completes and does not hang
     when its target event loop is running in a separate thread.
@@ -29,7 +37,7 @@ def test_grpc_service_publisher_does_not_hang_in_threaded_loop():
     # watcher = MagicMock(spec=ThreadWatcher)
     watcher = ThreadWatcher()  # A dummy watcher is sufficient for this test's purpose.
 
-    def run_loop_in_thread():
+    def run_loop_in_thread() -> None:
         asyncio.set_event_loop(new_loop)
         try:
             new_loop.run_forever()
@@ -40,7 +48,7 @@ def test_grpc_service_publisher_does_not_hang_in_threaded_loop():
                 task.cancel()
 
             # Gather cancelled tasks to allow them to finish
-            async def gather_cancelled():
+            async def gather_cancelled() -> None:
                 await asyncio.gather(*tasks, return_exceptions=True)
 
             new_loop.run_until_complete(gather_cancelled())
@@ -51,7 +59,7 @@ def test_grpc_service_publisher_does_not_hang_in_threaded_loop():
 
     publisher = GrpcServicePublisher(watcher, port=50051)  # Use a test-specific port
 
-    async def start_and_stop_publisher():
+    async def start_and_stop_publisher() -> None:
         try:
             # Schedule start_async to run on the dedicated event loop and wait for it
             start_future = asyncio.run_coroutine_threadsafe(
@@ -88,3 +96,168 @@ def test_grpc_service_publisher_does_not_hang_in_threaded_loop():
     if new_loop.is_running():
         new_loop.call_soon_threadsafe(new_loop.stop)
     thread.join(timeout=2)
+
+
+# Global test constants
+# Moved imports to the top
+TEST_HOST = "127.0.0.1"
+HEALTH_TEST_PORT = 50058  # Port for general health tests
+HEALTH_STATUS_CHANGE_PORT = 50059  # Port for specific status change tests
+
+
+@pytest_asyncio.fixture(scope="function")
+async def grpc_server_and_channel_info() -> (
+    AsyncIterator[Tuple[GrpcServicePublisher, GrpcChannelInfo]]
+):  # Removed event_loop parameter
+    """
+    Pytest fixture to set up a GrpcServicePublisher and a GrpcChannelInfo
+    for testing health check functionalities.
+    """
+    watcher = ThreadWatcher()
+    publisher = None
+    channel = None
+    channel_factory = InsecureGrpcChannelFactory()
+
+    try:
+        publisher = GrpcServicePublisher(watcher, HEALTH_TEST_PORT, addresses=TEST_HOST)
+
+        def connect_dummy(server: grpc.aio.Server) -> None:  # Changed to sync
+            # This dummy callback is sufficient as health service is auto-added
+            pass
+
+        await publisher.start_async(connect_dummy)
+        await asyncio.sleep(
+            0.1
+        )  # Brief pause after server start, before client channel creation
+
+        # Create channel to the server
+        channel = await channel_factory.find_async_channel(
+            addresses=TEST_HOST, port=HEALTH_TEST_PORT
+        )
+        assert channel is not None, "Channel creation failed in fixture"
+        channel_info = GrpcChannelInfo(
+            channel=channel, address=TEST_HOST, port=HEALTH_TEST_PORT
+        )
+        yield publisher, channel_info
+    finally:
+        if channel:
+            await channel.close()
+        if publisher:
+            await publisher.stop_async()
+
+
+@pytest.mark.asyncio
+class TestGrpcHealthChecks:
+    """Unit tests for gRPC health checking functionalities."""
+
+    async def test_service_healthy_when_server_running(
+        self, grpc_server_and_channel_info: Tuple[GrpcServicePublisher, GrpcChannelInfo]
+    ) -> None:
+        """
+        Tests that GrpcChannelInfo.is_healthy() returns True when the server is running.
+        """
+        publisher, channel_info = grpc_server_and_channel_info  # Changed back
+        assert publisher is not None, "Publisher should be initialized"
+        assert channel_info is not None, "GrpcChannelInfo should be initialized"
+        assert channel_info.channel is not None, "gRPC channel should be initialized"
+
+        is_healthy_status = await channel_info.is_healthy()
+        assert (
+            is_healthy_status is True
+        ), "Service should be healthy when server is running"
+
+    async def test_service_unhealthy_after_server_stop(
+        self, grpc_server_and_channel_info: Tuple[GrpcServicePublisher, GrpcChannelInfo]
+    ) -> None:
+        """
+        Tests that GrpcChannelInfo.is_healthy() returns False after the server is stopped.
+        """
+        publisher, channel_info = grpc_server_and_channel_info  # Changed back
+        assert (
+            await channel_info.is_healthy() is True
+        ), "Service should be healthy initially"
+
+        await publisher.stop_async()
+
+        # Short delay to allow server to fully stop and client to observe status change
+        await asyncio.sleep(0.1)
+
+        is_healthy_status_after_stop = await channel_info.is_healthy()
+        assert (
+            is_healthy_status_after_stop is False
+        ), "Service should be unhealthy after server stops"
+
+    async def test_health_check_overall_status_changes(
+        self,
+        _function_event_loop: asyncio.AbstractEventLoop,  # Changed to internal name
+    ) -> None:
+        """
+        Tests direct manipulation of health status on HealthServicer and its reflection
+        in GrpcChannelInfo.is_healthy().
+        """
+        watcher = ThreadWatcher()
+        publisher = None
+        channel = None
+        channel_factory = InsecureGrpcChannelFactory()
+
+        try:
+            publisher = GrpcServicePublisher(
+                watcher, HEALTH_STATUS_CHANGE_PORT, addresses=TEST_HOST
+            )
+
+            def connect_empty(server: grpc.aio.Server) -> None:  # Changed to sync
+                pass  # Health servicer is added automatically
+
+            await publisher.start_async(connect_empty)
+            await asyncio.sleep(1.0)  # Max sleep attempt for server to stabilize
+
+            health_servicer_instance = publisher._health_servicer
+            assert (
+                health_servicer_instance is not None
+            ), "_health_servicer should be initialized"
+
+            channel = await channel_factory.find_async_channel(  # Removed type hint redefinition
+                addresses=TEST_HOST, port=HEALTH_STATUS_CHANGE_PORT
+            )
+            assert channel is not None, "Channel creation failed in status change test"
+            channel_info = GrpcChannelInfo(
+                channel=channel, address=TEST_HOST, port=HEALTH_STATUS_CHANGE_PORT
+            )
+
+            # 1. Initial state should be SERVING
+            assert (
+                await channel_info.is_healthy() is True
+            ), "Overall status should be SERVING initially"
+
+            # 2. Change to NOT_SERVING
+            await health_servicer_instance.set(
+                "", health_pb2.HealthCheckResponse.NOT_SERVING
+            )  # Must be awaited
+            await asyncio.sleep(0.1)  # Allow propagation
+            assert (
+                await channel_info.is_healthy() is False
+            ), "Overall status set to NOT_SERVING should make is_healthy() False"
+
+            # 3. Change to UNKNOWN
+            await health_servicer_instance.set(
+                "", health_pb2.HealthCheckResponse.UNKNOWN
+            )  # Must be awaited
+            await asyncio.sleep(0.1)  # Allow propagation
+            assert (
+                await channel_info.is_healthy() is False
+            ), "Overall status set to UNKNOWN should make is_healthy() False"
+
+            # 4. Change back to SERVING
+            await health_servicer_instance.set(
+                "", health_pb2.HealthCheckResponse.SERVING
+            )  # Must be awaited
+            await asyncio.sleep(0.1)  # Allow propagation
+            assert (
+                await channel_info.is_healthy() is True
+            ), "Overall status set back to SERVING should make is_healthy() True"
+
+        finally:
+            if channel:
+                await channel.close()
+            if publisher:
+                await publisher.stop_async()

--- a/tsercom/rpc_e2etest.py
+++ b/tsercom/rpc_e2etest.py
@@ -11,9 +11,13 @@ from ipaddress import ip_address  # For SANs
 from typing import (
     Optional,
     Union,
+    AsyncIterator,  # Added
+    Tuple,  # Added
+    # Callable,
 )
 
 import grpc
+from tsercom.rpc.common.channel_info import GrpcChannelInfo  # Added import
 import pytest
 import pytest_asyncio
 from cryptography import x509
@@ -1394,6 +1398,40 @@ async def test_pinned_server_auth_server_changes_cert_fails(
 # --- Tests for ClientAuthGrpcChannelFactory (Scenario 3) ---
 
 
+HEALTH_E2E_TEST_PORT = 50060  # Use a fixed, non-zero port
+
+
+@pytest_asyncio.fixture(scope="function")
+async def health_e2e_server() -> AsyncIterator[Tuple[str, int, GrpcServicePublisher]]:
+    """
+    Pytest fixture to start a GrpcServicePublisher with only the health service.
+    Yields host, port, and the publisher instance.
+    """
+    watcher = ThreadWatcher()
+    publisher: Optional[GrpcServicePublisher] = None
+    host = "127.0.0.1"
+
+    try:
+        publisher = GrpcServicePublisher(
+            watcher, port=HEALTH_E2E_TEST_PORT, addresses=host
+        )
+
+        def dummy_connect(server: grpc.aio.Server) -> None:  # Ensured this is sync
+            # Health servicer is added automatically by GrpcServicePublisher
+            pass
+
+        await publisher.start_async(dummy_connect)
+
+        # Yielding the configured fixed port directly.
+        yield host, HEALTH_E2E_TEST_PORT, publisher
+
+    finally:
+        if publisher:
+            await publisher.stop_async()
+        # Add cleanup for ThreadWatcher if it had global state or unclosed resources
+        # watcher.stop() # Assuming ThreadWatcher has a stop method if needed
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("server_requires_client_auth", [False, True])
 async def test_client_auth_no_server_validation_by_client(
@@ -1457,7 +1495,7 @@ async def test_client_auth_no_server_validation_by_client(
 
 
 @pytest.mark.asyncio
-async def test_client_auth_with_server_validation_mtls(
+async def test_client_auth_with_server_validation_mtls(  # This is an existing test, the new fixture is added BEFORE it.
     secure_async_test_server_factory,
 ):
     """
@@ -1586,3 +1624,100 @@ async def test_client_auth_with_server_validation_untrusted_server_ca_fails(
                 "Closing channel that should not have been successfully created in untrusted server CA test."
             )
             await grpc_channel.close()
+
+
+# --- Health Check E2E Tests ---
+
+
+@pytest.mark.asyncio
+async def test_health_e2e_server_is_healthy(
+    health_e2e_server: Tuple[str, int, GrpcServicePublisher],
+) -> None:  # Added return type hint
+    """
+    Tests that a server started with health checking enabled reports as healthy.
+    """
+    host, port, publisher = health_e2e_server
+    assert publisher is not None, "Publisher from health_e2e_server fixture is None"
+
+    channel_factory = InsecureGrpcChannelFactory()
+    channel_info: Optional[GrpcChannelInfo] = None
+    client_channel: Optional[grpc.aio.Channel] = None
+
+    try:
+        client_channel = await channel_factory.find_async_channel(host, port)
+        assert (
+            client_channel is not None
+        ), f"Failed to connect to health_e2e_server at {host}:{port}"
+
+        channel_info = GrpcChannelInfo(channel=client_channel, address=host, port=port)
+
+        # Allow some time for the server to be fully ready and health status to be queryable
+        await asyncio.sleep(
+            0.2
+        )  # Similar to delays used in unit tests after server start
+
+        is_healthy = await channel_info.is_healthy()
+        assert (
+            is_healthy is True
+        ), f"Health check failed for server at {host}:{port}. Expected healthy."
+        logger.info(f"Server at {host}:{port} is healthy as expected.")
+
+    finally:
+        if client_channel:
+            await client_channel.close()
+
+
+@pytest.mark.asyncio
+async def test_health_e2e_server_becomes_unhealthy_after_stop(
+    health_e2e_server: Tuple[str, int, GrpcServicePublisher],
+) -> None:  # Added return type hint
+    """
+    Tests that a server reports as unhealthy after it has been stopped.
+    """
+    host, port, publisher = health_e2e_server
+    assert publisher is not None, "Publisher from health_e2e_server fixture is None"
+
+    channel_factory = InsecureGrpcChannelFactory()
+    client_channel: Optional[grpc.aio.Channel] = None
+    channel_info: Optional[GrpcChannelInfo] = None
+
+    try:
+        client_channel = await channel_factory.find_async_channel(host, port)
+        assert (
+            client_channel is not None
+        ), f"Failed to connect to health_e2e_server at {host}:{port}"
+
+        channel_info = GrpcChannelInfo(channel=client_channel, address=host, port=port)
+
+        # Allow some time for server to be fully ready and health status to be queryable
+        await asyncio.sleep(0.2)
+
+        is_healthy_initially = await channel_info.is_healthy()
+        assert (
+            is_healthy_initially is True
+        ), f"Server at {host}:{port} should be healthy initially."
+        logger.info(f"Server at {host}:{port} is healthy initially.")
+
+        # Stop the server
+        await publisher.stop_async()
+        logger.info(f"Server at {host}:{port} stopped via publisher.")
+
+        # Allow some time for the server to fully stop and health status to reflect this
+        await asyncio.sleep(0.2)
+
+        is_healthy_after_stop = await channel_info.is_healthy()
+        assert (
+            is_healthy_after_stop is False
+        ), f"Server at {host}:{port} should be unhealthy after stop."
+        logger.info(f"Server at {host}:{port} is unhealthy after stop, as expected.")
+
+    finally:
+        if client_channel:
+            # Channel might already be closed or error out if server stopped abruptly,
+            # so guard the close call.
+            try:
+                await client_channel.close()
+            except grpc.aio.AioRpcError:
+                logger.debug(
+                    "Channel already closed or errored on close after server stop."
+                )


### PR DESCRIPTION
This commit introduces a first-class gRPC health checking feature within Tsercom.

Key changes:

1.  **Server-Side (`GrpcServicePublisher` in `tsercom/rpc/grpc_util/grpc_service_publisher.py`):**
    *   The `GrpcServicePublisher` now automatically adds an instance of the asynchronous `grpc_health.v1._async.HealthServicer` to any server started via `start_async`.
    *   The `HealthServicer` instance is stored as `self._health_servicer`.
    *   Upon server start, the overall health of the service is immediately set to `SERVING` by awaiting `self._health_servicer.set("", health_pb2.HealthCheckResponse.SERVING)`.

2.  **Client-Side Utility (`check_grpc_channel_health` in `tsercom/rpc/grpc_util/grpc_service_publisher.py`):**
    *   A new standalone asynchronous function `check_grpc_channel_health(channel: grpc.aio.Channel) -> bool` has been created.
    *   This utility uses `HealthStub` from `grpc_health.v1.health_pb2_grpc` to perform a `Check` call on the provided channel.
    *   It returns `True` if the service reports `SERVING`, and `False` in all other cases, including `grpc.aio.AioRpcError` or other exceptions. Includes a 1-second timeout for the check.
    *   Enhanced logging was added to this function to aid in diagnostics.

3.  **Integration (`GrpcChannelInfo` in `tsercom/rpc/common/channel_info.py`):**
    *   The `ChannelInfo` dataclass has been renamed to `GrpcChannelInfo`.
    *   Its `channel` attribute type hint has been updated to `grpc.aio.Channel`.
    *   A new asynchronous method `async def is_healthy(self) -> bool:` has been added. This method simply calls and returns the result of `check_grpc_channel_health(self.channel)`.

4.  **Unit Tests (`grpc_service_publisher_unittest.py`):**
    *   A new test class `TestGrpcHealthChecks` has been added.
    *   Includes a pytest fixture `grpc_server_and_channel_info` to manage the lifecycle of a test server and client channel.
    *   Tests validate:
        *   `is_healthy()` returns `True` when the server is running and `SERVING`.
        *   `is_healthy()` returns `False` after the server has been stopped.
        *   Dynamic changes to the overall server health status (SERVING, NOT_SERVING, UNKNOWN) are correctly reflected by `is_healthy()`.

5.  **Debugging and Refinements:**
    *   Initial test failures were traced to using a synchronous `HealthServicer` with an async server. This was resolved by switching to `grpc_health.v1._async.HealthServicer` and ensuring its `set` method was correctly `await`ed in both the publisher and the unit tests.
    *   Static analysis tools (`black`, `ruff`, `mypy`) were run, and all reported issues were addressed, ensuring code quality and type safety.

All new and existing tests pass successfully with a 120-second timeout per test.
This implementation fulfills all requirements of the original issue.