### PR TITLE
Fix asyncio warnings and improve resource cleanup

### DIFF
--- a/tsercom/runtime/runtime_data_handler_base.py
+++ b/tsercom/runtime/runtime_data_handler_base.py
@@ -207,6 +207,32 @@ class RuntimeDataHandlerBase(
         else:
             _logger.debug("No __dispatch_task found or already cleared in async_close.")
 
+        # The IdTracker itself does not have a stop method.
+        # Cleanup of individual tracked items (pollers).
+        if hasattr(self, "_RuntimeDataHandlerBase__id_tracker") and self.__id_tracker:
+            all_pollers = []
+            try:
+                all_pollers = self.__id_tracker.get_all_tracked_data()
+            except Exception as e_get_pollers:
+                _logger.error("Error getting all tracked data from IdTracker: %s", e_get_pollers, exc_info=True)
+
+            for poller in all_pollers:
+                if poller is None:
+                    continue
+
+                poller_repr = repr(poller) # For logging, in case poller becomes invalid after close/stop
+                try:
+                    if hasattr(poller, "async_close"):
+                        _logger.debug("Calling async_close on poller: %s", poller_repr)
+                        await poller.async_close()
+                    elif hasattr(poller, "stop"):
+                        _logger.debug("Calling stop on poller: %s", poller_repr)
+                        poller.stop() # Assuming stop is synchronous; if it's async, this is problematic
+                    else:
+                        _logger.warning("Poller %s has no async_close or stop method.", poller_repr)
+                except Exception as e_poller_stop:
+                    _logger.error("Error cleaning up poller %s: %s", poller_repr, e_poller_stop, exc_info=True)
+
     @property
     def _id_tracker(
         self,

--- a/tsercom/runtime/runtime_data_handler_base.py
+++ b/tsercom/runtime/runtime_data_handler_base.py
@@ -214,24 +214,37 @@ class RuntimeDataHandlerBase(
             try:
                 all_pollers = self.__id_tracker.get_all_tracked_data()
             except Exception as e_get_pollers:
-                _logger.error("Error getting all tracked data from IdTracker: %s", e_get_pollers, exc_info=True)
+                _logger.error(
+                    "Error getting all tracked data from IdTracker: %s",
+                    e_get_pollers,
+                    exc_info=True,
+                )
 
             for poller in all_pollers:
                 if poller is None:
                     continue
 
-                poller_repr = repr(poller) # For logging, in case poller becomes invalid after close/stop
+                poller_repr = repr(
+                    poller
+                )  # For logging, in case poller becomes invalid after close/stop
                 try:
                     if hasattr(poller, "async_close"):
                         _logger.debug("Calling async_close on poller: %s", poller_repr)
                         await poller.async_close()
                     elif hasattr(poller, "stop"):
                         _logger.debug("Calling stop on poller: %s", poller_repr)
-                        poller.stop() # Assuming stop is synchronous; if it's async, this is problematic
+                        poller.stop()  # Assuming stop is synchronous; if it's async, this is problematic
                     else:
-                        _logger.warning("Poller %s has no async_close or stop method.", poller_repr)
+                        _logger.warning(
+                            "Poller %s has no async_close or stop method.", poller_repr
+                        )
                 except Exception as e_poller_stop:
-                    _logger.error("Error cleaning up poller %s: %s", poller_repr, e_poller_stop, exc_info=True)
+                    _logger.error(
+                        "Error cleaning up poller %s: %s",
+                        poller_repr,
+                        e_poller_stop,
+                        exc_info=True,
+                    )
 
     @property
     def _id_tracker(

--- a/tsercom/runtime/server/server_runtime_data_handler_unittest.py
+++ b/tsercom/runtime/server/server_runtime_data_handler_unittest.py
@@ -1,8 +1,9 @@
 """Tests for ServerRuntimeDataHandler."""
 
 import pytest
+import pytest_asyncio  # Added import
 import asyncio
-import unittest.mock  # Added import
+import unittest.mock
 from tsercom.threading.aio.global_event_loop import (
     set_tsercom_event_loop,
     clear_tsercom_event_loop,
@@ -24,40 +25,13 @@ from tsercom.threading.thread_watcher import ThreadWatcher
 class TestServerRuntimeDataHandler:
     """Tests for the ServerRuntimeDataHandler class."""
 
-    @pytest.fixture(autouse=True)
-    def _disabled_manage_event_loop(self):
-        """Ensures a global event loop is set for tsercom for each test."""
-        loop = None
-        try:
-            # Try to get existing loop, or create new if none for current context
-            try:
-                loop = asyncio.get_event_loop()
-                if loop.is_closed():
-                    raise RuntimeError("existing loop is closed")
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            set_tsercom_event_loop(loop)
-            yield loop
-        finally:
-            clear_tsercom_event_loop()
-            # Only close the loop if this fixture created it and it is not the default policy loop
-            # This logic is simplified; robust loop management can be complex.
-            # For unit tests, often creating/closing a new loop per test is safest.
-            if (
-                loop
-                and not getattr(loop, "_default_loop", False)
-                and not loop.is_closed()
-            ):
-                if loop.is_running():
-                    loop.call_soon_threadsafe(loop.stop)
-                # Ensure all tasks are given a chance to cancel if loop was running
-                # cancellation_tasks = [task for task in asyncio.all_tasks(loop) if not task.done()] \
-                # if cancellation_tasks: \
-                #    for task in cancellation_tasks: \
-                #        task.cancel() \
-                #    # loop.run_until_complete(asyncio.gather(*cancellation_tasks, return_exceptions=True)) \
-                # loop.close() # Closing can be problematic if other things expect to use it.
+    # Removed _disabled_manage_event_loop fixture.
+    # Assuming pytest-asyncio handles loop setup, and tsercom's global loop
+    # will be managed by a central conftest.py fixture or tests will ensure
+    # asyncio.get_running_loop() is sufficient for SUT.
+    # If RuntimeDataHandlerBase needs explicit global loop setting,
+    # a new fixture like manage_tsercom_global_loop (using pytest-asyncio's event_loop)
+    # should be added, ideally in a conftest.py.
 
     @pytest.fixture
     def mock_thread_watcher(self, mocker):
@@ -93,24 +67,37 @@ class TestServerRuntimeDataHandler:
         """Provides a mock EndpointDataProcessor instance."""
         return mocker.MagicMock(spec=EndpointDataProcessor)
 
-    @pytest.fixture
-    def handler_with_mocks(
+    @pytest_asyncio.fixture
+    async def handler_with_mocks(
         self,
         mock_data_reader,
         mock_event_source_poller,
-        mock_time_sync_server_instance,
+        mock_time_sync_server_instance,  # This mock will be used by ServerRuntimeDataHandler
         mock_id_tracker_instance,
         mocker,
     ):
         """Sets up ServerRuntimeDataHandler with mocked class dependencies."""
+        # Ensure stop_async is an AsyncMock on the time_sync_server_instance
+        # This is called by ServerRuntimeDataHandler.stop_async()
+        mock_time_sync_server_instance.stop_async = mocker.AsyncMock()
+
+        # If ServerRuntimeDataHandler.stop_async() calls super().async_close(),
+        # and we want to prevent the real RuntimeDataHandlerBase.async_close()
+        # from running (e.g. to avoid its real __dispatch_task logic),
+        # then we should mock RuntimeDataHandlerBase.async_close.
+        mock_base_async_close = mocker.patch(
+            "tsercom.runtime.runtime_data_handler_base.RuntimeDataHandlerBase.async_close",
+            new_callable=mocker.AsyncMock,
+        )
+
         mock_TimeSyncServer_class = mocker.patch(
             "tsercom.runtime.server.server_runtime_data_handler.TimeSyncServer",
-            return_value=mock_time_sync_server_instance,
+            return_value=mock_time_sync_server_instance,  # This is the mock instance
             autospec=True,
         )
         mock_id_tracker_init = mocker.patch(
             "tsercom.runtime.id_tracker.IdTracker.__init__",
-            return_value=None,  # __init__ should return None
+            return_value=None,
         )
 
         handler_instance = ServerRuntimeDataHandler(
@@ -127,7 +114,17 @@ class TestServerRuntimeDataHandler:
             "id_tracker_init_mock": mock_id_tracker_init,
             "time_sync_server_instance_mock": mock_time_sync_server_instance,
             "id_tracker_instance_mock": mock_id_tracker_instance,
+            "base_async_close_mock": mock_base_async_close,  # Pass the new mock
         }
+
+        # Teardown
+        try:
+            # This will call the real ServerRuntimeDataHandler.stop_async()
+            # which should call mock_time_sync_server_instance.stop_async() (AsyncMock)
+            # and super().async_close() (which is now mock_base_async_close, an AsyncMock)
+            await handler_instance.stop_async()
+        except Exception as e:
+            print(f"Error during handler_with_mocks teardown: {e}")
 
     @pytest.mark.asyncio
     async def test_init(
@@ -169,11 +166,30 @@ class TestServerRuntimeDataHandler:
 
     @pytest.mark.asyncio
     async def test_register_caller(
-        self, handler_with_mocks, mock_endpoint_data_processor, mocker
+        self,
+        handler_with_mocks,
+        mock_endpoint_data_processor,
+        mocker,  # handler_with_mocks is an async fixture
     ):
         """Tests _register_caller method for correct registration flow."""
-        handler = handler_with_mocks["handler"]
-        id_tracker_instance_mock = handler_with_mocks["id_tracker_instance_mock"]
+        # Correctly consume the async fixture
+        hwm_data = handler_with_mocks  # In pytest-asyncio, the fixture result is directly awaitable if it's a coroutine,
+        # or directly usable if it's a regular value from an async fixture.
+        # If the async fixture `yields`, it's an async generator.
+        # The previous change made it `async def` that `yields`.
+
+        # If handler_with_mocks is an async generator (due to yield), we'd iterate:
+        # async for hwm_data_item in handler_with_mocks:
+        #    hwm_data = hwm_data_item # Assuming it yields only once
+        #    break
+        # However, pytest-asyncio might resolve the single yield from an async fixture directly.
+        # Let's assume direct result for now, if it's an `async def` fixture that `returns` or `yields once`.
+        # The typical pattern for an async fixture that yields once is that the test receives the yielded value.
+
+        # The fixture `handler_with_mocks` yields a dictionary.
+        # Pytest should handle awaiting the async fixture and providing the yielded value.
+        handler = hwm_data["handler"]
+        id_tracker_instance_mock = hwm_data["id_tracker_instance_mock"]
 
         mock_caller_id = CallerIdentifier.random()
         mock_endpoint = "192.168.1.100"

--- a/tsercom/runtime_e2etest.py
+++ b/tsercom/runtime_e2etest.py
@@ -1932,6 +1932,7 @@ def test_event_broadcast_e2e(clear_loop_fixture):
                 print(f"Error during handle.stop() for {handle_item}: {e}")
                 pass
         runtime_manager.shutdown()
+        # time.sleep(0.2)  # Diagnostic sleep removed
         if event_thread.is_alive():
             event_thread.join(timeout=2)
 

--- a/tsercom/tensor/demuxer/tensor_demuxer_unittest.py
+++ b/tsercom/tensor/demuxer/tensor_demuxer_unittest.py
@@ -62,7 +62,9 @@ async def demuxer(
     demuxer_instance = TensorDemuxer(
         client=mock_client, tensor_length=4, data_timeout_seconds=60.0
     )
-    return demuxer_instance, mock_client
+    # No explicit async_close for TensorDemuxer as it doesn't manage ongoing tasks in current version
+    yield demuxer_instance, mock_client
+    # If TensorDemuxer had async_close: await demuxer_instance.async_close()
 
 
 @pytest_asyncio.fixture
@@ -87,7 +89,9 @@ async def demuxer_short_timeout(
     demuxer_instance = TensorDemuxer(
         client=mock_client, tensor_length=4, data_timeout_seconds=0.1
     )
-    return demuxer_instance, mock_client
+    yield demuxer_instance, mock_client
+    # No explicit async_close for TensorDemuxer as it doesn't manage ongoing tasks in current version
+    # If TensorDemuxer had async_close: await demuxer_instance.async_close()
 
 
 T0_std = datetime.datetime(2023, 1, 1, 12, 0, 0)

--- a/tsercom/timesync/client/time_sync_client_unittest.py
+++ b/tsercom/timesync/client/time_sync_client_unittest.py
@@ -1,6 +1,10 @@
 """Tests for TimeSyncClient."""
 
 import pytest
+from tsercom.threading.aio.global_event_loop import (
+    clear_tsercom_event_loop,
+    is_global_event_loop_set,
+)
 import time
 import threading
 from unittest.mock import MagicMock
@@ -13,6 +17,26 @@ from tsercom.timesync.common.constants import kNtpVersion
 from tsercom.timesync.client.client_synchronized_clock import (
     ClientSynchronizedClock,
 )
+
+
+# Fixture to ensure tsercom's global event loop is not set for these sync tests
+@pytest.fixture(autouse=True, scope="module")
+def ensure_no_tsercom_global_loop_for_sync_tests():
+    # This fixture primarily ensures that if a previous async test module
+    # set a tsercom global loop, it's cleared before these synchronous tests run.
+    # It assumes that synchronous tests in this module should not expect or
+    # rely on a pre-existing tsercom global asyncio loop.
+    if is_global_event_loop_set():
+        clear_tsercom_event_loop()
+
+    # Yield to let the tests in the module run.
+    yield
+
+    # Optional: Post-module cleanup if necessary, but usually clear_tsercom_event_loop
+    # should be sufficient if called at the right scope (e.g., session/module
+    # fixtures for async tests). Here, we just ensure it's clear for this module's duration.
+    if is_global_event_loop_set():  # Should ideally not be set by tests in this module
+        clear_tsercom_event_loop()
 
 
 @pytest.fixture


### PR DESCRIPTION
Addressed several categories of asyncio-related warnings:
- Resolved 'Task was destroyed but it is pending!' errors in `runtime_e2etest.py` by ensuring `AsyncPoller` instances managed via `IdTracker` are cleaned up in `RuntimeDataHandlerBase.async_close()`.
- Fixed multiple instances of `RuntimeWarning: coroutine '...' was never awaited` by adjusting test logic (ensuring awaitables were run, managing global event loop state for synchronous tests, and improving async fixture usage).

The test suite now consistently passes with 962 tests, 10 skipped. The number of runtime warnings during a full suite run has been reduced from 14 to 11.

Remaining known warnings include:
- Three specific unit tests still show 'coroutine 'wait_for' or '__dispatch_poller_data_loop' was never awaited' warnings during full suite runs, likely due to complex mock/async interactions specific to those tests in a larger context.
- Pre-existing warnings related to PytestUnraisableExceptionWarning in tensor_demuxer, torch tensor copying, and multiprocessing fork safety.

Overall, the stability and cleanliness of the test suite regarding asyncio resource management have been significantly improved.