### PR TITLE
Fix: Resolve test failures and ruff issues

### DIFF
--- a/tsercom/api/runtime_manager_helpers.py
+++ b/tsercom/api/runtime_manager_helpers.py
@@ -58,9 +58,7 @@ class ProcessCreator:
             # BaseContext does not define .Process, but concrete contexts do.
             # Use getattr and cast to satisfy mypy.
             process_constructor_attr = getattr(self._context, "Process", None)
-            if not process_constructor_attr or not callable(
-                process_constructor_attr
-            ):
+            if not process_constructor_attr or not callable(process_constructor_attr):
                 logger.error(
                     "Context %s does not have a callable 'Process' attribute.",
                     type(self._context).__name__,

--- a/tsercom/runtime/runtime_config.py
+++ b/tsercom/runtime/runtime_config.py
@@ -58,7 +58,7 @@ class RuntimeConfig(Generic[DataTypeT]):
         min_send_frequency_seconds: float | None = None,
         auth_config: BaseChannelAuthConfig | None = None,
         max_queued_responses_per_endpoint: int = 1000,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
         data_reader_sink_is_lossy: bool = True,
     ):
@@ -92,7 +92,7 @@ class RuntimeConfig(Generic[DataTypeT]):
         min_send_frequency_seconds: float | None = None,
         auth_config: BaseChannelAuthConfig | None = None,
         max_queued_responses_per_endpoint: int = 1000,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
         data_reader_sink_is_lossy: bool = True,
     ):
@@ -136,7 +136,7 @@ class RuntimeConfig(Generic[DataTypeT]):
         min_send_frequency_seconds: float | None = None,
         auth_config: BaseChannelAuthConfig | None = None,
         max_queued_responses_per_endpoint: int = 1000,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
         data_reader_sink_is_lossy: bool = True,
     ):
@@ -250,7 +250,7 @@ class RuntimeConfig(Generic[DataTypeT]):
         self.__max_queued_responses_per_endpoint: int = (
             max_queued_responses_per_endpoint
         )
-        self.__max_ipc_queue_size: Optional[int] = max_ipc_queue_size
+        self.__max_ipc_queue_size: int | None = max_ipc_queue_size
         self.__is_ipc_blocking: bool = is_ipc_blocking
         self.__data_reader_sink_is_lossy: bool = data_reader_sink_is_lossy
 
@@ -346,7 +346,7 @@ class RuntimeConfig(Generic[DataTypeT]):
         return self.__max_queued_responses_per_endpoint
 
     @property
-    def max_ipc_queue_size(self) -> Optional[int]:
+    def max_ipc_queue_size(self) -> int | None:
         """The maximum size of core inter-process communication queues.
 
         This value is used for the `maxsize` parameter of `multiprocessing.Queue`

--- a/tsercom/runtime/runtime_data_handler_base.py
+++ b/tsercom/runtime/runtime_data_handler_base.py
@@ -125,7 +125,7 @@ class RuntimeDataHandlerBase(
             is_global_event_loop_set,
         )
 
-        self._loop_on_init: asyncio.AbstractEventLoop | None = None 
+        self._loop_on_init: asyncio.AbstractEventLoop | None = None
         if is_global_event_loop_set():
             self._loop_on_init = get_global_event_loop()
             self.__dispatch_task = self._loop_on_init.create_task(

--- a/tsercom/threading/multiprocess/default_multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/default_multiprocess_queue_factory.py
@@ -49,7 +49,7 @@ class DefaultMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
 
     def create_queues(
         self,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
     ) -> tuple[MultiprocessQueueSink[T], MultiprocessQueueSource[T]]:
         """
@@ -67,7 +67,8 @@ class DefaultMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
             A tuple containing MultiprocessQueueSink and MultiprocessQueueSource
             instances, both using a context-aware `multiprocessing.Queue` internally.
         """
-        # A maxsize of <= 0 for multiprocessing.Queue means platform-dependent default (effectively "unbounded").
+        # A maxsize of <= 0 for multiprocessing.Queue means platform-dependent
+        # default (effectively "unbounded").
         effective_maxsize = 0
         if max_ipc_queue_size is not None and max_ipc_queue_size > 0:
             effective_maxsize = max_ipc_queue_size

--- a/tsercom/threading/multiprocess/multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/multiprocess_queue_factory.py
@@ -8,7 +8,7 @@ which is considered for deprecation in favor of concrete factory implementations
 """
 
 from abc import ABC, abstractmethod
-from typing import TypeVar, Tuple, Generic
+from typing import Generic, TypeVar
 
 from tsercom.threading.multiprocess.multiprocess_queue_sink import (
     MultiprocessQueueSink,
@@ -31,7 +31,7 @@ class MultiprocessQueueFactory(ABC, Generic[QueueTypeT]):
     @abstractmethod
     def create_queues(
         self,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
     ) -> tuple[MultiprocessQueueSink[QueueTypeT], MultiprocessQueueSource[QueueTypeT]]:
         """

--- a/tsercom/threading/multiprocess/torch_memcpy_queue_factory.py
+++ b/tsercom/threading/multiprocess/torch_memcpy_queue_factory.py
@@ -7,13 +7,9 @@ from typing import (
     Any,
     Generic,
     TypeVar,
-    Callable,
-    Any,
-    Union,
-    Iterable,
-    Optional,
 )
-import torch 
+
+import torch
 import torch.multiprocessing as mp
 
 from tsercom.threading.multiprocess.multiprocess_queue_factory import (
@@ -74,7 +70,7 @@ class TorchMemcpyQueueFactory(
 
     def create_queues(
         self,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
     ) -> tuple[
         "TorchMemcpyQueueSink[QueueElementT]",
@@ -133,14 +129,14 @@ class TorchMemcpyQueueSource(
     def __init__(
         self,
         queue: "mp.Queue[QueueElementT]",
-        tensor_accessor: Optional[
-            Callable[[QueueElementT], Union[torch.Tensor, Iterable[torch.Tensor]]]
-        ] = None,
+        tensor_accessor: (
+            Callable[[QueueElementT], torch.Tensor | Iterable[torch.Tensor]] | None
+        ) = None,
     ) -> None:
         super().__init__(queue)
-        self.__tensor_accessor: Optional[
-            Callable[[QueueElementT], Union[torch.Tensor, Iterable[torch.Tensor]]]
-        ] = tensor_accessor
+        self.__tensor_accessor: (
+            Callable[[QueueElementT], torch.Tensor | Iterable[torch.Tensor]] | None
+        ) = tensor_accessor
 
     def get_blocking(self, timeout: float | None = None) -> QueueElementT | None:
         """
@@ -200,15 +196,15 @@ class TorchMemcpyQueueSink(
     def __init__(
         self,
         queue: "mp.Queue[QueueElementT]",
-        tensor_accessor: Optional[
-            Callable[[QueueElementT], Union[torch.Tensor, Iterable[torch.Tensor]]]
-        ] = None,
+        tensor_accessor: (
+            Callable[[QueueElementT], torch.Tensor | Iterable[torch.Tensor]] | None
+        ) = None,
         is_blocking: bool = True,
     ) -> None:
         super().__init__(queue, is_blocking=is_blocking)
-        self.__tensor_accessor: Optional[
-            Callable[[QueueElementT], Union[torch.Tensor, Iterable[torch.Tensor]]]
-        ] = tensor_accessor
+        self.__tensor_accessor: (
+            Callable[[QueueElementT], torch.Tensor | Iterable[torch.Tensor]] | None
+        ) = tensor_accessor
 
     def put_blocking(self, obj: QueueElementT, timeout: float | None = None) -> bool:
         """

--- a/tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py
+++ b/tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py
@@ -1,7 +1,8 @@
 """Defines a factory for creating torch.multiprocessing queues."""
 
 import multiprocessing as std_mp
-from typing import Tuple, TypeVar, Generic
+from typing import Generic, TypeVar
+
 import torch.multiprocessing as mp
 
 from tsercom.threading.multiprocess.multiprocess_queue_factory import (
@@ -51,7 +52,7 @@ class TorchMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
 
     def create_queues(
         self,
-        max_ipc_queue_size: Optional[int] = None,
+        max_ipc_queue_size: int | None = None,
         is_ipc_blocking: bool = True,
     ) -> tuple[MultiprocessQueueSink[T], MultiprocessQueueSource[T]]:
         """Creates a pair of torch.multiprocessing queues wrapped in Sink/Source.
@@ -72,7 +73,8 @@ class TorchMultiprocessQueueFactory(MultiprocessQueueFactory[T], Generic[T]):
             A tuple containing MultiprocessQueueSink and MultiprocessQueueSource
             instances, both using a torch.multiprocessing.Queue internally.
         """
-        # For torch.multiprocessing.Queue, maxsize=0 means platform default (usually large).
+        # For torch.multiprocessing.Queue, maxsize=0 means platform default
+        # (usually large).
         effective_maxsize = 0
         if max_ipc_queue_size is not None and max_ipc_queue_size > 0:
             effective_maxsize = max_ipc_queue_size


### PR DESCRIPTION
This commit addresses initial test failures and all ruff linting issues.

Test Failures Fixed:
- Resolved `NameError: name 'Optional' is not defined` in:
  - `tsercom/threading/multiprocess/multiprocess_queue_factory.py`
  - `tsercom/threading/multiprocess/default_multiprocess_queue_factory.py`
  - `tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py` This was the root cause of all initial test collection errors.

Ruff Issues Fixed:
- Ran `ruff check . --fix` to auto-correct numerous issues.
- Manually corrected remaining `E501 Line too long` errors by:
  - Reformatting comments in:
    - `tsercom/threading/multiprocess/default_multiprocess_queue_factory.py`
    - `tsercom/threading/multiprocess/torch_multiprocess_queue_factory.py`
  - Reformatting long type hint lines in:
    - `tsercom/threading/multiprocess/torch_memcpy_queue_factory.py`

Verification:
- All tests pass consistently (`pytest --timeout=120` run twice).
- `ruff check .` reports no issues.
- `mypy tsercom/` reports no issues.
- `black .` reformatted one file, subsequent runs show no changes needed.